### PR TITLE
fix(deps): bump rustls-webpki to patch RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` 0.103.12 → 0.103.13 via `cargo update -p rustls-webpki`
- Unblocks CI (cargo-deny fails on [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104))

## Threat
Advisory describes a reachable panic parsing an empty `BIT STRING` in the `onlySomeReasons` element of an `IssuingDistributionPoint` CRL extension. **kos does not use CRL revocation**, so the bug is not exploitable here — this is a transitive patch bump to satisfy the policy gate.

## Wider question (not in this PR)
kos only pulls the TLS stack for `updater.rs` (self-update). The updater is only partially wired and is a candidate for removal in favor of platform-level distribution (sideshow). Opening a separate thread for that.

## Test plan
- [x] `cargo update -p rustls-webpki` — single-package patch bump, no SEMVER churn
- [ ] CI Cargo Deny job goes green
- [ ] CI Test / Clippy / Rustfmt jobs unaffected