### PR TITLE
docs: knowledge-system research drop (survey, nine improvements, use assessment, roadmap v3.1)

### DIFF
--- a/_kos/probes/brief-kos-status-woz.md
+++ b/_kos/probes/brief-kos-status-woz.md
@@ -1,0 +1,39 @@
+# Exploration Brief — kos status Wizard-of-Oz (roadmap#29 / kos#64)
+
+**Date opened:** 2026-07-04
+**Question:** Does a session-entry status verb — "where am I in the
+cycle, what's the next verb" — actually get consulted and change
+operator behavior, when it costs nearly nothing to run?
+**Hypothesis:** The R1 inversion holds: given a free status verb, the
+operator (human or agent) consults it at session start and the next
+verb it suggests is followed more often than not. If the operator
+won't consult a nearly-free status verb, no amount of engineering
+makes the tool-drives-process inversion real (party round 2, Maya).
+
+**predicted_confidence:** 0.7 that status is consulted in >=2/3 of
+sessions once wired into session-start habit; 0.5 that the suggested
+next verb is followed without modification.
+
+**Instrument:** `aae-orc/tools/kos-status` (bash, deliberately not
+Rust). Sections: open probe loops, unharvested findings, stale
+frontier, validate + uncommitted _kos state, bd ready count, single
+next-verb suggestion. Every invocation appends to
+`~/.kos-status-woz/<date>.jsonl` — usage telemetry is the experiment's
+own measurement (per-session file family; no shared writer).
+
+**Timebox:** three real working cycles (per round-2 consensus:
+promote to Rust only after surviving three cycles).
+
+**Success signal:** invocation log shows habitual use; at least one
+session where the surfaced obligation (e.g. unharvested finding)
+was acted on and would plausibly have been missed otherwise.
+
+**Kill criterion (registered now, per Quinn's round-1 demand):** if
+after three cycles the log shows <=1 voluntary invocation per session,
+or the next-verb suggestion is systematically ignored, the WoZ dies
+and roadmap#29's design is rethought before any Rust ships — the
+failure would falsify R1's core mechanism, not just this script.
+
+**Non-goals:** enforcement of any kind; fixture-workspace AC (that's
+the Rust implementation's AC in kos#64); hooks (gated on the
+environment contract, kos#65).

--- a/docs/kos-nine-improvements-reassessed.md
+++ b/docs/kos-nine-improvements-reassessed.md
@@ -1,0 +1,153 @@
+# The Nine Improvements, Re-Read Through the Survey and Roadmap v3
+
+> Cross-document assessment: `kos-nine-improvements.md` evaluated against
+> the literature survey's failure-mode findings and roadmap v3's
+> integration decisions. Citations use the survey's citekeys; full BibTeX
+> entries are in `kos-roadmap-v3.md`.
+
+**Verdict distribution: 2 strengthened, 3 modified, 3 correctly deferred,
+1 partially killed.**
+
+---
+
+## Strengthened
+
+### #5 Retrodiction
+
+The survey's biggest gift to any single proposal. The backtesting
+literature [@bailey2014pseudo] and hindsight-bias work
+[@fischhoff1975hindsight; @dekker2002field] convert the "graveyard risk"
+the nine-doc named (hindsight leakage) from a caveat into a designed
+control: blinding isn't mitigation, it *is* the experiment. v3 correctly
+promoted this to first science item.
+
+One thing the nine-doc got right that deserves note: it pre-registered a
+prediction (≥2 of 4 incidents detectable at T-minus-one-sprint) before
+knowing the method literature — that instinct is exactly the
+registered-reports discipline [@nosek2014registered] the survey later
+validated.
+
+### #8 MCP Server
+
+Horvitz's mixed-initiative principle [@horvitz1999principles] plus the
+LLIS retrieval-at-need failure [@weber2001intelligent] upgrade this from
+"integration convenience" to "the delivery mechanism the entire literature
+says is mandatory." Benefit must arrive inside the agent's task loop, not
+in a separate consultation step. v3's promotion into milestone MR is
+right.
+
+---
+
+## Modified
+
+### #3 Confidence Half-Life
+
+The nine-doc invented decay classes (durable/stable/volatile) with
+admittedly arbitrary horizons. ACT-R base-level activation
+[@anderson1991reflections] replaces invention with a validated
+formalization where decay is *retrieval-reinforced* — which creates a
+dependency the original missed: you cannot compute retrieval-weighted
+decay without retrieval counts. Hence v3 sequencing it behind #7's
+telemetry. The original's "graveyard risk: arbitrary horizons" is now
+resolved, but the improvement gains a hard prerequisite.
+
+### #7 Knowledge Economics
+
+Survives intact mechanically, but the survey adds a warning the nine-doc
+lacked: Austin's measurement dysfunction [@austin1996measuring].
+Retrieval counts as *diagnostic* telemetry are fine; the moment they
+become status metrics ("your nodes are never read"), authors optimize for
+retrieval-bait. The original's Hawthorne acceptance ("bias toward more
+graph use is desired") was too casual — Goodhart cuts deeper than
+Hawthorne. v3's diagnostic-never-gate rule is the fix.
+
+### #2 Canary Nodes
+
+Strengthened *and* constrained. Mutation testing [@demillo1978hints] and
+chaos engineering [@basiri2016chaos] give it lineage; Goodhart gives it a
+promotion — v3 names canary detection-rate as the *only* game-resistant
+health metric. But the survey implies a constraint the original missed:
+canaries test detection of *corruption*, not detection of *staleness or
+gaps* — different failure classes need different canary templates. The
+template library needs a taxonomy matching the six signal types before
+planting.
+
+---
+
+## Correctly Deferred
+
+### #1 Source Reliability Ledger
+
+The Admiralty two-axis insight survives conceptually (provenance ≠
+confidence; never merge the fields), but with one human and few agent
+versions, grades cannot discriminate — and worse, the
+intelligence-analysis literature the survey touched (structured analytic
+techniques' mixed empirical validation) suggests reliability grading is
+precisely the kind of SAT whose real-world efficacy is *asserted more
+than measured*. The deferral trigger (≥4 sustained sources) is right.
+
+### #6 Dissent Nodes
+
+The historiography instinct is sound, but at n=1 human the mechanism
+records nothing the graveyard doesn't. The parked trigger (second
+sustained operator) is correct. Note for when it reopens: the two
+backfill candidates identified (Q4-vs-Q5 prioritization;
+charter-freeze-vs-query-cited-edits) remain valid test material.
+
+### #9 Chronicle
+
+Grudin-safe by construction (pure read-side), which is why it survives at
+all. But it reuses Issue 21's traversal machinery, so sequencing behind
+the query layer isn't deferral — it's dependency. The
+citation-per-sentence discipline in the original anticipated the
+grounded-generation requirement correctly.
+
+---
+
+## Partially Killed
+
+### #4 Toulmin Fields
+
+The survey's most direct hit on the nine-doc. Argumentation formalisms
+are the *canonical* Grudin victim: gIBIS [@conklin1988gibis], QOC, and
+the whole design-rationale program died on exactly this intrusiveness
+[@shipman1997design] — "Formality Considered Harmful"
+[@shipman1999formality] reads as a pre-written obituary for the proposal.
+The original's own graveyard risk ("if authors skip it, another soft
+constraint") understated the case: the literature says authors *will*
+skip it, universally, across four decades of attempts.
+
+What survives is instructive: **one field, `rebuttal_conditions`, on
+bedrock only** — and it survives not as argumentation but because it
+doubles as Issue 24's machine-checkable reopener vocabulary. The lesson
+generalizes: **formal structure earns admission only when a machine
+consumes it.** Structure for human readers alone is dead weight;
+structure the tooling acts on is infrastructure.
+
+---
+
+## Two Cross-Cutting Observations
+
+**The nine-doc's implicit theme was validated.** Its closing note flagged
+#1/#2/#5 as "testing the graph's epistemics, not just its yield." The
+survey independently converged: the three paper-shaped claims named in v3
+(retrodiction, reopener triggers, calibrated briefs) are all
+epistemics-testing; none are yield features. The instinct preceded the
+literature.
+
+**The nine-doc's blind spot was cost accounting.** Every proposal carried
+a "graveyard risk," but only #4 and #7 seriously reckoned with
+*author-side cost* — and Grudin says that is the only risk that has
+historically killed anything [@grudin1996evaluating]. Re-scored on
+cost/benefit posture:
+
+| Posture | Improvements | Outcome |
+| --- | --- | --- |
+| Author-neutral (read-side) | #5, #8, #9 | All survive strong |
+| Machine-paid | #2, #7 | Survive |
+| Author-light | #3 | Survives with prerequisite |
+| Author-taxed at write time | #1, #4, #6 | One killed, two deferred |
+
+The correlation is perfect. The single sharpest lesson the research adds
+to the improvements document: **the survival predictor was never novelty
+or rigor — it was who pays.**

--- a/docs/kos-nine-improvements.md
+++ b/docs/kos-nine-improvements.md
@@ -1,0 +1,287 @@
+# KOS — Nine Improvements Beyond the Current Vision
+
+> Constraint honored: none of these appear in the conversation's design
+> history, the repo/zip, or roadmap v1/v2. Each is specified to probe depth:
+> concept, why it's underserved, mechanism, first probe, and the risk that
+> would graveyard it.
+
+---
+
+## 1. Source Reliability Ledger (Admiralty grading for provenance)
+
+**Concept.** Intelligence tradecraft solved epistemic provenance a century
+ago: rate the *source* (A–F reliability) separately from the *information*
+(1–6 credibility). KOS records who created a node but never accumulates a
+track record. A ledger derives per-source reliability from history: how
+often a source's nodes reach bedrock vs. get superseded/graveyarded, and
+(once Issue 10 runs) their calibration error.
+
+**Why underserved.** Provenance is currently identity, not trust. An agent
+that confabulated three findings and a human with a 90% bedrock-survival
+rate produce nodes of identical standing. Every retrieval treats them
+equally.
+
+**Mechanism.** `provenance.created_by` becomes a foreign key into
+`_kos/sources/<id>.yaml` (reliability grade, computed stats, manual
+override + rationale). Queries gain `--min-reliability`. Ripple propagation
+weights by source grade. Grades recompute at harvest.
+
+**First probe.** Backfill grades from the existing 43 findings' survival
+history; check whether grade predicts which frontier nodes later promoted.
+
+**Graveyard risk.** With few distinct sources (one human, few agent
+versions), grades may not discriminate. n may be too small until the
+platform has more operators.
+
+---
+
+## 2. Canary Nodes — adversarial self-testing of the epistemics
+
+**Concept.** Mutation testing for knowledge. Periodically inject known-false
+but plausible nodes (a fabricated bedrock claim, a subtly wrong dependency,
+a stale-but-confident finding) under sealed registration. Measure
+time-to-detection and detection channel (drift? contradiction? human?
+never?).
+
+**Why underserved.** Every validation to date measures whether KOS finds
+signal in *others'* corpora. Nothing measures the graph's immune response
+to corruption in itself — the exact failure mode (silent agent corruption)
+that motivated the typed-edge design in session-001.
+
+**Mechanism.** `kos canary plant` writes a node from a template library and
+a sealed record to `_kos/.canaries/` (gitignored, hash-committed so planting
+is provable but contents hidden). `kos canary reveal` scores outstanding
+canaries. Detection SLO becomes a health metric.
+
+**First probe.** Plant 3 canaries across confidence tiers; run 5 normal
+sessions; reveal. Hypothesis: contradiction-bearing canaries get caught,
+orphan-plausible ones survive indefinitely.
+
+**Graveyard risk.** Operators who know canaries exist change behavior
+(Hawthorne effect). Mitigate with random long delays and low base rate.
+
+---
+
+## 3. Confidence Half-Life — temporal decay of bedrock
+
+**Concept.** Bedrock is currently immortal; real knowledge stales at
+domain-dependent rates. Give confidence a half-life: each node carries
+`verified_at` and a decay class (physics-slow: values, non-goals;
+market-fast: tool comparisons, version facts). Past its re-verification
+horizon, bedrock degrades to `bedrock-stale` — still authoritative, but
+flagged in every retrieval and queued for cheap re-verification.
+
+**Why underserved.** Drift detection is *event*-driven (content hash of
+dependencies changed). Nothing handles *erosion* — the world changing while
+the graph's inputs sit untouched. `elem-context-ceiling`'s measurements,
+the standards-landscape evaluation, the tool graveyards (skillshare,
+speckit): all decay-class-fast, all treated as permanent.
+
+**Mechanism.** Schema: `decay_class: durable | stable | volatile` with
+default horizons (∞ / 12mo / 3mo). `kos stale` lists past-horizon nodes;
+re-verification is a micro-probe (confirm → reset clock; fail → demote with
+finding).
+
+**First probe.** Classify the 23 bedrock nodes; count how many are already
+past a reasonable horizon. Prediction: ≥4 volatile-class items verified
+only at creation.
+
+**Graveyard risk.** Horizon-setting is arbitrary until calibration data
+exists; may generate re-verification busywork. Start with volatile class
+only.
+
+---
+
+## 4. Traversable Reasoning — Toulmin fields on nodes
+
+**Concept.** Nodes store conclusions; reasoning lives in prose and dies
+there. Add optional structured argumentation: `claim` (the title),
+`grounds` (edge refs to evidence), `warrant` (why grounds support claim,
+one sentence), `rebuttal_conditions` (what observation would defeat this).
+The reasoning becomes queryable: "show me every bedrock whose warrant
+depends on single-operator observation."
+
+**Why underserved.** The substrate hypothesis names "preserved reasoning
+chains" as a property files can't provide — and defers it to a future
+substrate. This captures 60% of that property now, at schema level, no
+migration. It also operationalizes reopeners: `rebuttal_conditions` are
+machine-checkable reopener triggers, where today's graveyard reopeners are
+prose.
+
+**Mechanism.** Schema v0.4 optional block; validate warns when bedrock
+lacks `rebuttal_conditions` (unfalsifiable bedrock is the smell). `kos why
+<node>` renders the argument tree by traversing grounds recursively.
+
+**First probe.** Retrofit the 3 founding values + 5 newest bedrock; attempt
+`kos why val-typed-traversable`. Does the tree bottom out in evidence or in
+assertion? Either answer is a finding.
+
+**Graveyard risk.** Ceremony cost — if authors skip it, it becomes another
+soft constraint. Gate only on bedrock promotion, nowhere else.
+
+---
+
+## 5. Retrodiction Engine — `kos asof` and historical seam replay
+
+**Concept.** The strongest KOS claims are counterfactuals: "the graph would
+have caught #6 before implementation" (finding-023). Test them. Git makes
+time travel free: `kos asof <date>` reconstructs the graph at a historical
+commit; replay seam detection against the documents as they existed then;
+check whether known-later incidents were predictable at that state.
+
+**Why underserved.** Roadmap Issue 11 tests the present (baseline vs.
+graph, today). Nothing tests the *temporal* claim — early detection — which
+is the actual product pitch. Retrodiction converts the anecdote into a
+measured rate: of N incidents with known discovery dates, KOS-at-T-minus-30
+flags K.
+
+**Mechanism.** `kos asof <ref> -- <subcommand>` (checkout to temp worktree,
+run, discard). A retrodiction harness pairs ThreeDoors incident dates with
+pre-incident document states.
+
+**First probe.** The four ThreeDoors incidents. Prediction registered
+before running: ≥2 of 4 detectable at T-minus-one-sprint. This is the
+single highest-credibility experiment available to the project.
+
+**Graveyard risk.** Hindsight leakage — the person building the historical
+graph knows the incidents. Mitigate: bootstrap the historical state from
+documents only, by an operator blinded to which incidents are being tested.
+
+---
+
+## 6. Dissent Nodes — minority reports at promotion time
+
+**Concept.** The graph records outcomes; it cannot hold "B overruled A."
+Graveyard is *ruled out*; dissent is *unresolved but overridden* — a live
+alternative that lost the promotion decision without being falsified. A
+`dissent` node attaches to a promotion, preserving the losing argument, its
+author, and its trigger condition for reconsideration.
+
+**Why underserved.** Historiography self-corrects through minority reports;
+KOS currently launders disagreement into false consensus at every promote
+step. The human-as-pawl model makes this worse: when the human overrules an
+agent (or vice versa), the override is invisible. finding-019 says humans
+see what the graph can't — dissent nodes record when the graph's own
+operators saw differently from each other.
+
+**Mechanism.** `kos promote --with-dissent <file>`; dissent nodes carry
+`overridden_by`, `trigger` (condition for revisit), and edge
+`dissents_from → <promoted node>`. `kos stale`/audit surfaces dissents
+whose triggers have fired.
+
+**First probe.** Mine the conversation history: at least two documented
+splits exist (Q4-vs-Q5 prioritization; "no charter edits" vs. "query-cited
+edits"). Backfill them; check whether either trigger has since fired.
+
+**Graveyard risk.** Low volume in a one-human project. Value scales with
+operator count — may be premature until the platform has more voices.
+
+---
+
+## 7. Knowledge Economics — retrieval telemetry and node ROI
+
+**Concept.** Every node has a creation cost (session tokens, human minutes)
+and a realized value (retrieval count, participation in consequential
+findings). Nothing measures either. Instrument the read path: orient,
+query, and (future) subgraph-context calls log node IDs served. Compute
+cost-per-consequential-finding and identify dead weight — nodes never
+retrieved after creation.
+
+**Why underserved.** Mary's "read-utility per token" metric was proposed
+for the charter only and never built. Generalized, it answers the questions
+the project keeps arguing from intuition: is the graph earning its
+maintenance cost? Which node types pay rent? Is 92%-derives connective
+tissue ever traversed at all?
+
+**Mechanism.** Append-only `_kos/.telemetry/reads.jsonl` (node_id, command,
+session, ts); `kos economics` reports retrieval distribution, orphan-read
+rate, cost proxies from provenance timestamps. Privacy-trivial: it's all
+local.
+
+**First probe.** Instrument for 10 sessions; hypothesis: retrieval follows
+a power law and ≥40% of nodes are never read after their creating session.
+Either result reshapes pruning and schema priorities.
+
+**Graveyard risk.** Measuring reads changes reading (operators perform
+retrieval). Accept it — the bias direction is toward *more* graph use,
+which is the desired behavior anyway.
+
+---
+
+## 8. Epistemic API — KOS as an MCP server
+
+**Concept.** Expose the graph read-only over Model Context Protocol:
+`kos serve --mcp` offering tools (`orient`, `query_frontier`,
+`subgraph_context`, `why`, `chronicle`) to *any* MCP-capable agent —
+marvel workers, director, Claude Desktop, foreign tooling. KOS stops being
+a repo-local CLI and becomes queryable infrastructure.
+
+**Why underserved.** The roadmap's query layer (Issues 7–9) is
+session-and-human facing: CLI invocations inside the repo. The platform's
+own architecture (marvel teams, director protocol, F10 cross-repo
+continuity) needs agents *elsewhere* to consult the graph mid-task — the
+exact "orientation loss" failure F10 documents. An MCP surface is the
+missing integration primitive, and it makes the external-operator probe
+(Issue 13) trivial to run: hand someone the endpoint.
+
+**Mechanism.** Rust MCP server module wrapping existing workspace loaders;
+read-only in v1 (writes stay in the harvest path, preserving the
+promotion pawl); serves the Issue-7 subgraph context format verbatim.
+
+**First probe.** One marvel worker mid-task asks `query_frontier(scope=X)`
+instead of reading a CLAUDE.md; measure whether it avoids one documented
+repeated-settled-question failure (F10's concrete failure mode).
+
+**Graveyard risk.** Premature if Issue 7's format isn't settled — gate on
+it. Concurrency reads on YAML are safe; this dodges the substrate question
+rather than answering it.
+
+---
+
+## 9. Chronicle — narrative projection of causal history
+
+**Concept.** The graph projects documents; it should also project *story*.
+`kos chronicle <node>` walks provenance and edge chains chronologically and
+renders the history of an idea as readable narrative with citations: what
+question spawned it, what probes tested it, what died so it could live,
+who dissented, when it hardened. Durant for a codebase: the graph already
+contains the civilization's records; nothing yet writes its history.
+
+**Why underserved.** Onboarding, stakeholder communication, and the
+"outside reader cannot reconstruct project state" problem (v2 assessment
+F8, Issue 13) are all narrative problems. Every current projection is
+structural (charter sections, mermaid graphs, YAML). Humans consolidate
+understanding through story; the graph has the raw material and no
+renderer. This is also the shadow principle completed: documents,
+diagrams, *and narrative* as projections of one source.
+
+**Mechanism.** Deterministic traversal (chronological topo-sort of the
+node's ancestry + contradicts/supersedes/dissent events) emitting a
+structured event list; optional LLM pass converts events to prose, with
+every sentence citing node IDs — grounded generation, hallucination
+detectable by citation check.
+
+**First probe.** `kos chronicle elem-storage-model` — the richest lineage
+in the graph (session-001 design → grv-git-semantic-layer →
+grv-git-as-sufficient-substrate → substrate hypothesis). Hand the output
+to a cold reader; measure comprehension against the Issue-13 baseline.
+
+**Graveyard risk.** The LLM prose pass can smuggle unsupported claims;
+the citation-per-sentence discipline is the control. If citation coverage
+can't reach ~100%, ship the event list and skip the prose.
+
+---
+
+## Cross-cutting note
+
+Three of these (1, 2, 5) share a theme absent from the entire project to
+date: **testing the graph's epistemics, not just its yield.** Reliability
+grading tests sources, canaries test detection, retrodiction tests the
+early-warning claim. Together they would move KOS from "a system that
+finds signal" to "a system whose trustworthiness is itself measured" —
+which is the difference between an instrument and a methodology.
+
+Suggested first adoptions if forced to pick two: **#5 Retrodiction** (the
+highest-credibility experiment available, nearly free via git) and
+**#8 MCP server** (converts the platform's biggest documented failure mode,
+F10, into a solved integration).

--- a/docs/kos-prior-work-survey.md
+++ b/docs/kos-prior-work-survey.md
@@ -1,0 +1,789 @@
+# Mapping KOS (Knowledge Operating System) to Prior Work: A Breadth-First Literature Survey with Emphasis on Failure Modes
+
+## TL;DR
+
+- **The single biggest lesson from five decades of adjacent research is that KOS’s core mechanisms map onto a *graveyard of well-intentioned systems that died for the same recurring reasons*** — design rationale capture, requirements traceability, knowledge management, model-driven engineering, the Semantic Web, and literate programming all failed primarily because the cost of capture fell on people who did not reap the benefit (asymmetric cost/benefit), formalization imposed cognitive overhead, captured knowledge decayed unmaintained, and metrics became gaming targets [@grudin1996evaluating; @shipman1999formality; @marshall2003which; @austin1996measuring].
+- **KOS’s central survival bet must be that AI agents absorb the capture cost**, breaking the asymmetry (Grudin/Weber) that doomed prior systems; several concepts are well-grounded (prediction-error learning, ACT-R-style confidence decay, TMS-based tiering) but two — the **append-only graveyard of negative knowledge** and **retrodictive replay for early-warning validation** — are exactly where prior work is most damning and where KOS is methodologically most exposed to hindsight/look-ahead bias [@fischhoff1975hindsight; @weber2001intelligent].
+- **Nine of the seventeen concepts warrant deeper follow-up treatment** (flagged below), chiefly because the literature identifies specific, unresolved failure modes that KOS could either fall into or, with careful design, contribute genuinely novel solutions to — especially “epistemic chaos engineering,” automated incremental formalization, and valid point-in-time retrodiction protocols.
+
+## Key Findings
+
+1. **The asymmetric cost/benefit problem is the number-one killer of knowledge-capture systems.** It independently sank design rationale [@grudin1996evaluating], requirements traceability [@gotel1994analysis], knowledge management, and MDE [@hutchinson2014model]. Any KOS design requiring humans to manually author graph content will replicate these deaths.
+1. **Formality is costly and frequently counterproductive.** Shipman & Marshall’s “Formality Considered Harmful” [@shipman1999formality] and Marshall & Shipman’s “Which Semantic Web?” [@marshall2003which] show forced premature classification drives abandonment; *incremental formalization* is the escape hatch.
+1. **Metrics on knowledge become targets** [@austin1996measuring]: any incentive attached to node counts or contribution scores will be gamed.
+1. **Captured knowledge decays**, and stale-but-trusted knowledge is worse than absent knowledge (traceability decay, link rot, ACT-R base-level decay).
+1. **Automation induces complacency and deskilling** [@bainbridge1983ironies; @parasuraman2010complacency] — a first-order risk for a human–AI knowledge system.
+1. **Retrodictive validation is contaminated by hindsight and look-ahead bias** [@fischhoff1975hindsight] unless strictly blinded.
+1. **Some knowledge is genuinely uncodifiable** [@polanyi1966tacit; @collins2010tacit], and every classification scheme creates invisible residual categories [@bowker1999sorting].
+
+## Details
+
+### 1. Typed knowledge graphs with epistemic confidence tiers (bedrock/frontier/graveyard)
+
+**Supportive.** Doyle’s Truth Maintenance System [@doyle1979tms] introduced justification records so beliefs can be retracted when assumptions change; de Kleer’s ATMS [@dekleer1986atms] tracks, for each fact, the assumption sets (“environments”) under which it holds and maintains minimal inconsistent sets (“nogoods”) — a direct formal analogue of an append-only ruled-out record. AGM belief revision [@alchourron1985agm] formalizes rational belief change (expansion/contraction/revision), grounding tiered, revisable nodes.
+
+**Critical / do-not-do.** TMS/ATMS are computationally expensive; the ATMS can blow up combinatorially in the number of environments. Do **not** attempt global logical consistency across the whole graph — de Kleer’s tractability derived from *minimal* nogoods and local reasoning. AGM’s logical omniscience and single-consistent-belief-set assumptions are unrealistic for a large, multi-author, contradiction-laden project base; treat tiers as social/epistemic labels, not a globally satisfiable logic.
+
+**Further research. *Recommended for deeper treatment*:** formally mapping bedrock/frontier/graveyard onto belief-revision operators (a graveyard entry as a stored contraction with a justification; a “reopener” as the re-expansion condition), and combining probabilistic/possibilistic confidence with symbolic justification.
+
+### 2. The graveyard: append-only negative knowledge
+
+**Supportive.** Recording ruled-out approaches (approach/context/finding/ruling/reopener) is backed by the negative-results movement and organizational-learning theory, and resembles a durable decision record.
+
+**Critical / do-not-do (priority).** This is the most dangerous concept because it is precisely what design-rationale and lessons-learned systems tried and largely failed at. Designers are documented as reluctant to record rejected alternatives (Conklin & Yakemovic). Grudin [@grudin1996evaluating] names the fatal asymmetry: capture cost falls on non-beneficiaries. At organizational scale, the GAO’s audit of NASA’s Lessons Learned Information System [@gao2002nasa] — surveying 192 managers overseeing roughly 240 programs and projects — found that “lessons are not routinely identified, collected, or shared”; managers reported that LLIS “is not the primary source for lessons learning,” instead relying on “program reviews and informal discussions with colleagues,” with the chief barriers being “lack of time to capture or submit lessons and a perception of intolerance for mistakes.” Weber, Aha & Becerra-Fernandez [@weber2001intelligent] found that despite large repositories “their information is not being used,”  and argued lessons-learned systems fail when they “introduce new processes” instead of embedding into existing workflow.
+
+Do-not-do: (1) do not require manual, out-of-band authoring of negative entries — capture must be a by-product of existing work; (2) do not rely on cultures that punish mistakes; (3) do not assume retrieval will happen — an unqueried lesson is worthless.
+
+**Further research. *Recommended for deeper treatment*:** whether LLM agents can auto-populate the graveyard from commit history, PR discussions, and incident postmortems (embedding capture in workflow, per Weber’s prescription), breaking the intrusiveness/asymmetry deadlock that killed prior systems.
+
+### 3. Design rationale and argumentation structure
+
+**Supportive.** The Toulmin model [@toulmin1958uses], Rittel’s IBIS, Conklin & Begeman’s gIBIS, and MacLean et al.‘s QOC give vocabularies for design deliberation; Dung’s abstract argumentation frameworks [@dung1995acceptability] give formal semantics for which positions are defensible under attack relations.
+
+**Critical / do-not-do (priority).** Design rationale is the canonical cautionary tale. Buckingham Shum & Hammond [@shum1994argumentation] asked “what use at what cost?” and documented heavy capture costs for uncertain downstream benefit. Grudin [@grudin1996evaluating] documented intrusiveness and cost/benefit asymmetry. Shipman & Marshall’s “Formality Considered Harmful” [@shipman1999formality] is the key finding: forcing premature formalization causes abandonment because users resist fitting fluid ideas into rigid node/link types; their remedy is *incremental formalization* — letting structure emerge on demand.
+
+Do-not-do: do not force up-front classification of every node/edge; do not make argument structure mandatory; do not assume rationale captured for one audience serves another.
+
+**Further research. *Recommended for deeper treatment*:** LLM-assisted, post-hoc rationale reconstruction from communication artifacts (the “documentation perspective” Shipman & McCall favored).
+
+### 4. Requirements traceability and spec-code correspondence
+
+**Supportive.** Gotel & Finkelstein’s empirical analysis (100+ practitioners) [@gotel1994analysis] is foundational, distinguishing pre-RS from post-RS traceability. Reflexion Models [@murphy1995software] compare a high-level model against extracted source structure — directly relevant to spec-code correspondence. Consistency checking (xlinkit [@nentwich2003flexible]) offers scalable rule-based link checking; Perry & Wolf [@perry1992foundations] introduced architectural erosion/drift.
+
+**Critical / do-not-do (priority).** Traceability decays and its benefit is asymmetric. Gotel & Finkelstein showed most problems stem from inadequate *pre-RS* traceability — the informal, tacit reasoning before a spec is written, exactly what is hardest to capture. The “traceability benefit problem” (Arkley & Riddle): link maintainers rarely benefit, so links go stale. DOORS-class tools are widely adopted in regulated industries but carry high maintenance burden.
+
+Do-not-do: do not create trace links requiring manual maintenance disconnected from artifacts; do not assume link completeness; treat stale links as actively harmful (false confidence).
+
+**Further research. *Recommended for deeper treatment*:** whether KOS’s typed spec-code links can be continuously *regenerated/validated* (IR → BERT/LLM trace-link generation is an active ICSE/RE topic) rather than manually maintained, and how to surface link decay as a first-class signal.
+
+### 5. Documents and code as lossy projections of an underlying model
+
+**Supportive.** Single-source-of-truth and model-driven engineering (MDE) share KOS’s premise; projectional editing and Knuth’s literate programming [@knuth1984literate] (“explaining to human beings what we want the computer to do”) articulate the vision.
+
+**Critical / do-not-do (priority).** The empirical MDE record is a warning. Hutchinson, Whittle et al. [@hutchinson2011empirical; @hutchinson2014model] found success/failure is driven by “complex organizational, managerial and social factors,”  not technical merit; Whittle, Hutchinson & Rouncefield [@whittle2014state], surveying 450 MDE practitioners with 22 in-depth interviews, concluded that “although MDE might be more widespread than commonly believed, developers rarely use it to generate whole systems. Rather, they apply MDE to develop key parts of a system.” Round-trip engineering is notoriously brittle. Literate programming, despite technical elegance, never achieved broad adoption — tooling complexity (WEB/CWEB tied to TeX) and maintenance overhead confined it to niche reproducible-research use.
+
+Do-not-do: do not assume the “underlying model” fully generates all projections; do not force bidirectional round-trip sync; the maintainer-vs-beneficiary asymmetry recurs here too.
+
+**Further research. *Recommended for deeper treatment*:** treating projections as *lossy and regenerable* (compiler-like) rather than authoritative bidirectional sync.
+
+### 6. Prediction-error learning / calibration
+
+**Supportive.** One of KOS’s best-grounded concepts. Schultz, Dayan & Montague’s dopamine reward-prediction-error work [@schultz1997neural] and the predictive-processing / free-energy framework [@friston2010free; @clark2013whatever] establish prediction error as a fundamental learning signal, grounding “surprise_magnitude at harvest.” Forecasting-calibration research — Brier scoring, Tetlock’s *Expert Political Judgment* [@tetlock2005expert] and *Superforecasting* [@tetlock2015superforecasting] — shows calibration is measurable and trainable: in the Good Judgment Project, probability-training produced roughly a 6% Brier-score improvement in year 3 and about 7% in year 4, and Schoemaker & Tetlock separately report that as little as one hour of training improved accuracy by about 14% over a year. Pre-registration and registered reports directly support pre-registered hypotheses with predicted_confidence.
+
+**Critical / do-not-do.** Kerr’s HARKing [@kerr1998harking] is the key hazard: if predictions are recorded *after* outcomes, calibration is meaningless. Tetlock’s own extremizing-aggregation caveat (some tournament gains may have been partly a fluke) warns against over-trusting aggregation tricks.
+
+Do-not-do: do not allow predicted_confidence to be edited after harvest — timestamp and lock predictions; guard against Goodhart effects on calibration scores (§14).
+
+**Further research.** Automated surprise detection triggering belief revision (links §1 and §6).
+
+### 7. Organizational memory and knowledge management
+
+**Supportive.** Walsh & Ungson’s organizational memory [@walsh1991organizational] and Stein & Zwass’s organizational memory information systems provide the frame; Nonaka’s SECI model [@nonaka1994dynamic] describes tacit↔explicit conversion; Wegner’s transactive memory [@wegner1987transactive] explains how groups distribute “who knows what.”
+
+**Critical / do-not-do (priority).** The 1990s–2000s KM movement is a graveyard. Multi-case failure studies find lack of incentives and the absence of an appropriate/usable system to be the most significant barriers; KM failed when it was too IT-centric, lacked contribution incentives, and ignored culture. Nonaka’s SECI is critiqued for treating tacit→explicit conversion as unproblematic (§8).
+
+Do-not-do: do not build a repository and assume contribution; do not ignore incentives; do not treat tacit knowledge as fully codifiable.
+
+**Further research. *Recommended for deeper treatment*:** whether AI agents change the incentive calculus by removing the human-contribution bottleneck.
+
+### 8. Tacit knowledge limits
+
+**Supportive.** Polanyi’s tacit dimension [@polanyi1966tacit] (“we can know more than we can tell”) and Collins’s taxonomy [@collins2010tacit] — relational, somatic, and collective tacit knowledge  — bound what a graph can capture; Collins argues only *collective* tacit knowledge is truly uncodifiable, while relational is capturable in principle. Cook & Brown’s “knowing vs. knowledge” [@cook1999bridging] and Tsoukas’s distributed-knowledge view of the firm critique codification.
+
+**Critical / do-not-do (priority).** Suchman’s *Plans and Situated Actions* [@suchman1987plans] shows plans are resources for action, not determinants — a warning against over-formalization. Bowker & Star’s *Sorting Things Out* [@bowker1999sorting] documents that every classification scheme produces *residual categories* (“other”) and makes some things invisible, with “torque” when lived experience does not fit — a direct warning about typed nodes and confidence tiers.
+
+Do-not-do: do not assume the graph captures everything that matters; explicitly design for residual/uncategorizable knowledge; do not let the scheme’s blind spots become organizational blind spots.
+
+**Further research. *Recommended for deeper treatment*:** representing the *boundary* of what is captured (metadata about what is deliberately excluded).
+
+### 9. Human–AI collaborative cognition and distributed cognition
+
+**Supportive.** Hutchins’s distributed cognition [@hutchins1995cognition] and Clark & Chalmers’s extended mind [@clark1998extended] frame KOS as external cognitive scaffolding; Horvitz’s mixed-initiative principles [@horvitz1999principles] guide human–AI interaction.
+
+**Critical / do-not-do (priority).** Bainbridge’s “Ironies of Automation” [@bainbridge1983ironies] is essential: automating the routine leaves humans to handle exactly the cases automation cannot, while their skills atrophy. Parasuraman & Manzey [@parasuraman2010complacency] document automation complacency and bias — operators of consistently reliable systems are markedly worse at detecting failures, and complacency “cannot be overcome with simple practice.” 
+
+Do-not-do: do not let KOS cause humans to stop exercising judgment about knowledge validity; guard against automation bias (trusting graph assertions because the system is usually right); preserve human domain-reasoning skill.
+
+**Further research. *Recommended for deeper treatment*:** designing KOS to *counter* rather than induce complacency (surfacing uncertainty, forcing engagement).
+
+### 10. Provenance and trust
+
+**Supportive.** The W3C PROV data model [@moreau2013prov] (Entity/Activity/Agent) is the canonical provenance standard; the NATO/Admiralty source-reliability grading [@nato2016ajp21] (reliability A–F, credibility 1–6) directly parallels KOS’s source grading; Heuer’s *Psychology of Intelligence Analysis* [@heuer1999psychology] motivates structured methods to counter bias.
+
+**Critical / do-not-do (priority).** Structured Analytic Techniques have surprisingly weak empirical validation. Dhami, Belton & Mandel [@dhami2019analysis] found analysts trained in Analysis of Competing Hypotheses “did not follow all of the steps of ACH”  and it did not reliably reduce bias. The Admiralty scale itself shows raters clustering on the A1/B2/C3 diagonal, indicating reliability and credibility are not judged independently.
+
+Do-not-do: do not assume a structured grading scheme improves judgment; validate empirically; do not conflate source reliability with information credibility.
+
+**Further research. *Recommended for deeper treatment*:** empirical evaluation of whether KOS’s confidence tiers actually improve decisions.
+
+### 11. Memory architectures for LLM agents
+
+**Supportive.** Retrieval-augmented generation [@lewis2020retrieval], Microsoft GraphRAG, MemGPT [@packer2023memgpt] (OS-inspired virtual-memory paging), and Park et al.‘s Generative Agents [@park2023generative] (memory stream + recency/importance/relevance retrieval + reflection) are directly relevant. Cognitive architectures SOAR and ACT-R [@anderson2004integrated] provide decades-tested formalizations; ACT-R’s base-level activation — activation as a function of frequency and recency  with a decay parameter (community default ~0.5)  — is an *existing formalization of “confidence half-life.”*
+
+**Critical / do-not-do.** Ablation evidence: removing reflection in Generative Agents caused behavior to degenerate “from coherent multi-day planning to repetitive, context-free responses within 48 simulated hours”; its fixed relevance-and-recency heuristic “required extensive manual tuning” and “could not learn from memory management errors.” MemGPT’s paging can introduce latency. Memory poisoning is a documented emerging attack; catastrophic forgetting remains a continual-learning hazard.
+
+Do-not-do: do not rely on hand-tuned retrieval heuristics; do not ignore memory-corruption/poisoning threats; do not assume more memory = better performance.
+
+**Further research. *Recommended for deeper treatment*:** adopting ACT-R base-level activation as KOS’s principled decay/confidence model instead of an ad-hoc half-life, and defending against memory poisoning (links §15).
+
+### 12. Knowledge decay and half-life
+
+**Supportive.** Arbesman’s *Half-Life of Facts* [@arbesman2012halflife] documents measurable obsolescence: Poynard et al. sampled cirrhosis/hepatitis studies from 1945–1999 and had experts judge each conclusion true/false/obsolete as of 2000, yielding a reported ~45-year truth half-life (critics note this is inflated because survival was measured from publication to 2000). ACT-R base-level decay [@anderson2004integrated] gives a cognitive-science formalization. Link-rot studies find random web-page half-life of approximately two years (a 2016–17 Yahoo! Directory study likewise found ~two years), whereas a 2002 study found only ~3% of digital-library objects inaccessible after a year, implying a half-life of nearly 23 years.
+
+**Critical / do-not-do.** Schema/ontology evolution is a known failure point — changing the schema can silently invalidate prior assertions; external references rot.
+
+Do-not-do: do not treat any confidence assignment as permanent; version the schema; monitor external-reference decay.
+
+**Further research.** Empirically calibrating decay rates per knowledge type (bedrock facts persist for decades; others rot in months).
+
+### 13. Wikis / ontologies / Semantic Web as cautionary tales
+
+**Supportive (primarily cautionary).** The Semantic Web vision and Cyc [@lenat1990cyc] represent the maximal ambition of formalized knowledge.
+
+**Critical / do-not-do (priority).** Marshall & Shipman’s “Which Semantic Web?” [@marshall2003which] is definitive on authoring cost: “learning a knowledge representation language or tool requires the author to learn about the representation’s methods of abstraction and their effect on reasoning… Once one has learned a formal representation language, it is still often much more effort to express ideas in that representation than in a less formal representation.” The grand agent vision largely did not materialize because authoring cost and brittle ontologies were underestimated. Cyc, running since 1984, is critiqued for lacking a theoretical foundation, being unable to perform induction, and remaining “crystalline” (non-probabilistic);  despite decades and hundreds of person-years it has not yielded general common-sense AI. Enterprise wikis are frequently abandoned.
+
+Do-not-do: do not require heavy up-front ontology engineering; do not assume contributors will learn a formal representation; do not build a brittle global ontology.
+
+**Further research. *Recommended for deeper treatment*:** whether LLMs finally reduce the authoring-cost barrier that killed the Semantic Web.
+
+### 14. Self-referential / reflexive systems and metrics
+
+**Supportive.** Goodhart’s law and Campbell’s law formalize measurement dysfunction.
+
+**Critical / do-not-do (priority).** Austin’s *Measuring and Managing Performance in Organizations* [@austin1996measuring] is the key text: when any important dimension is unmeasured, incentive-linked measurement is doomed to dysfunction as people optimize the measured at the expense of the unmeasured (Ridgway’s classic “dysfunctional consequences of performance measurements” predates it). CMM/CMMI maturity efforts spawned “process theater” — compliance activity that satisfies auditors without improving outcomes.
+
+Do-not-do: do not attach incentives to KOS knowledge metrics (node counts, contribution scores); use metrics for informational/process improvement only, never individual performance; assume any metric will be gamed.
+
+**Further research. *Recommended for deeper treatment*:** measuring KOS health without inducing dysfunction.
+
+### 15. Canary / adversarial epistemics
+
+**Supportive.** Mutation testing (DeMillo, Lipton & Sayward [@demillo1978hints]; the “coupling effect”) — deliberately injecting faults to test whether tests catch them — maps directly to injecting false knowledge to test detection. Chaos engineering (Basiri et al. [@basiri2016chaos]; Netflix’s Chaos Monkey/Kong) validates resilience by inducing failures in production. Red-teaming and data-poisoning-detection literature complete the picture.
+
+**Critical / do-not-do.** Mutation testing is computationally expensive and suffers “equivalent mutants” (mutations that don’t change behavior, wasting analysis). Chaos engineering in production carries real risk. Injecting false knowledge into a shared graph risks contaminating it if the canary isn’t perfectly tracked and removed.
+
+Do-not-do: do not inject adversarial knowledge without airtight provenance and rollback; beware equivalent-mutant-style false negatives.
+
+**Further research. *Recommended for deeper treatment*:** a principled “epistemic chaos engineering” methodology for knowledge graphs — a genuinely novel contribution KOS could make.
+
+### 16. Retrodiction and hindsight
+
+**Supportive.** Backtesting methodology (finance) provides replay techniques; resilience engineering (Woods) and incident analysis inform replaying historical graph states.
+
+**Critical / do-not-do (priority).** Fischhoff’s “Hindsight ≠ Foresight” [@fischhoff1975hindsight] is the essential warning: outcome knowledge inflates judged prior likelihood, and judges are “largely unaware” of the effect. Dekker [@dekker2014field] shows hindsight bias corrupts accident investigation — observers with outcome knowledge wrongly conclude operators “should have seen it.” Backtesting in finance is plagued by overfitting and look-ahead bias (accidentally using information unavailable at the replayed time).
+
+Do-not-do: KOS’s plan to replay historical graph states to test early-warning claims is *highly vulnerable to look-ahead bias* — do not let any post-hoc information leak into the replayed state; do not evaluate early-warning claims with knowledge of what actually happened absent strict blinding.
+
+**Further research. *Recommended for deeper treatment*:** rigorous protocols (point-in-time reconstruction, blinding) to make retrodictive early-warning tests valid — where KOS is methodologically most exposed.
+
+### 17. Federated / distributed knowledge across repositories
+
+**Supportive.** Conway’s law is empirically validated: MacCormack, Baldwin & Rusnak’s mirroring hypothesis [@maccormack2012exploring] found products “mirror the architectures of the organizations” that build them;  Nagappan, Murphy & Basili [@nagappan2008influence] found organizational metrics predicted failure-prone Windows Vista binaries better than code metrics.  Carlile’s framework [@carlile2004transferring] distinguishes syntactic (transfer), semantic (translation), and pragmatic (transformation) knowledge boundaries , with boundary objects [@carlile2002pragmatic] spanning them.
+
+**Critical / do-not-do.** Carlile’s key lesson: at *pragmatic* boundaries actors have different interests, so knowledge cannot simply be transferred — it must be transformed, which is political and effortful. Federating knowledge across teams/repos will hit these boundaries; API/schema federation shows semantic mismatch across repositories.
+
+Do-not-do: do not assume a shared schema resolves cross-team knowledge boundaries; the hardest boundaries are pragmatic (differing interests), not syntactic.
+
+**Further research.** Boundary objects for human-AI-team knowledge federation.
+
+## Recommendations
+
+**Stage 1 — Design guardrails to adopt now (before building further):**
+
+- **Make AI agents bear the capture cost.** Treat any requirement for manual human authoring of nodes/edges/graveyard entries as a red flag; capture must be a by-product of existing developer workflow (commits, PRs, incidents). *Benchmark that would change this:* if pilot data shows humans will voluntarily author ≥ the needed content without incentives, the asymmetry constraint relaxes — but the base rate from KM/DR/LLIS says they will not.
+- **Enforce incremental formalization** [@shipman1999formality]: never require up-front classification; let structure emerge on demand.
+- **Lock predictions.** predicted_confidence and hypotheses must be timestamped and immutable post-harvest to preserve calibration validity and prevent HARKing [@kerr1998harking].
+- **Never attach incentives to knowledge metrics** [@austin1996measuring]; use them only for process feedback.
+
+**Stage 2 — Empirical validation to prioritize:**
+
+- Run a controlled study of whether KOS’s confidence tiers actually improve human decisions (the SAT literature warns structured schemes often do not [@dhami2019analysis]).
+- Instrument graveyard *retrieval*, not just capture — an unqueried graveyard is the LLIS failure mode [@gao2002nasa; @weber2001intelligent]. *Threshold:* if graveyard entries are not queried before repeating ruled-out approaches, the feature is failing regardless of how complete it is.
+- Adopt ACT-R base-level activation [@anderson2004integrated] as the principled decay model and calibrate decay rates per knowledge type against observed re-validation events.
+
+**Stage 3 — Novel contributions to pursue (highest research upside):**
+
+- Formalize **“epistemic chaos engineering”** (deliberate false-knowledge injection with airtight provenance/rollback) — no prior discipline exists; KOS could define it.
+- Build a **valid retrodiction protocol** (point-in-time reconstruction + blinding) for early-warning claims; this is where KOS is most exposed to hindsight/look-ahead bias [@fischhoff1975hindsight] and where a rigorous method would be a real contribution.
+- Test whether **LLM-borne capture and formalization** finally dissolves the cost/benefit asymmetry (Grudin/Weber gap) and the Semantic Web authoring-cost barrier (Marshall & Shipman gap).
+
+**Research venues.** KOS naturally sits across five communities: **CSCW/CHI** (design rationale, incremental formalization, human-AI teaming, automation bias); **ICSE/FSE/RE** (traceability, MDE, architecture erosion, reflexion models); **KR/AAAI/ISWC** (TMS, belief revision, ontologies, provenance); **Organization Science/Management** (organizational memory, KM failure, boundary objects, measurement dysfunction); and **NeurIPS/ACL/agent venues** (LLM memory, GraphRAG, continual learning).
+
+**Open questions anchored in literature gaps:** (1) Does AI-borne capture cost finally solve the asymmetric cost/benefit problem that killed design rationale and KM? (2) Can incremental formalization be automated so structure emerges without user overhead? (3) What is a valid retrodictive protocol free of hindsight/look-ahead bias? (4) Can ACT-R base-level activation serve as a principled confidence-decay model for a project knowledge graph? (5) What does epistemic chaos engineering look like as a discipline? (6) How can knowledge-graph health be measured without Goodhart dysfunction?
+
+## Caveats
+
+- **Search-budget limits.** A small number of concepts were sourced partly through the citation gap-filler rather than direct reading of the primary text: Conway’s-law empirical studies (§17), Carlile’s boundary framework (§17), mutation testing/chaos engineering primary papers (§15), literate-programming non-adoption (§5), and the NATO/Admiralty grading standard (§10). The bibliographic details (years, venues, DOIs) were cross-checked, but a few page ranges and edition details (e.g., AJP-2.1 exact edition/year; Dekker edition) should be verified against the publisher before publication.
+- **Literate programming’s “failure” is a well-attested community narrative, not a single peer-reviewed post-mortem;** it is best framed as limited adoption outside reproducible-research niches, not a documented collapse.
+- **The Admiralty A–F/1–6 six-grade form is the modern NATO standard;** the WWII original used a five-grade credibility scale. The independence critique of the scale rests on older studies (Baker et al.) and should be presented as suggestive.
+- **The ~45-year clinical-fact half-life** [@arbesman2012halflife] is contested; critics note the measurement window (publication-to-2000) inflates apparent longevity. Cite it as illustrative of measurable decay, not a precise constant.
+- **Some LLM-agent-memory sources are recent arXiv preprints** (MemGPT, Generative Agents ablations, memory-poisoning work) that may not be peer-reviewed in final form; the seminal items (Park et al. UIST 2023; Lewis et al. NeurIPS 2020) are archival.
+- **A few relations in the task brief were reframed by the evidence:** Carlile’s 2004 paper is titled “Transferring, Translating, and Transforming” (the “Pragmatic View” title is his 2002 paper); both are cited. Where the literature was thin or contested, this is flagged in-line rather than smoothed over.
+
+## BibTeX Bibliography
+
+```bibtex
+@article{doyle1979tms,
+  author = {Doyle, Jon},
+  title = {A Truth Maintenance System},
+  journal = {Artificial Intelligence},
+  volume = {12},
+  number = {3},
+  pages = {231--272},
+  year = {1979},
+  doi = {10.1016/0004-3702(79)90008-0}
+}
+
+@article{dekleer1986atms,
+  author = {de Kleer, Johan},
+  title = {An Assumption-Based {TMS}},
+  journal = {Artificial Intelligence},
+  volume = {28},
+  number = {2},
+  pages = {127--162},
+  year = {1986},
+  doi = {10.1016/0004-3702(86)90080-9}
+}
+
+@article{alchourron1985agm,
+  author = {Alchourr{\'o}n, Carlos E. and G{\"a}rdenfors, Peter and Makinson, David},
+  title = {On the Logic of Theory Change: Partial Meet Contraction and Revision Functions},
+  journal = {Journal of Symbolic Logic},
+  volume = {50},
+  number = {2},
+  pages = {510--530},
+  year = {1985},
+  doi = {10.2307/2274239}
+}
+
+@incollection{grudin1996evaluating,
+  author = {Grudin, Jonathan},
+  title = {Evaluating Opportunities for Design Capture},
+  booktitle = {Design Rationale: Concepts, Techniques, and Use},
+  editor = {Moran, Thomas P. and Carroll, John M.},
+  publisher = {Lawrence Erlbaum Associates},
+  address = {Mahwah, NJ},
+  pages = {453--470},
+  year = {1996}
+}
+
+@techreport{gao2002nasa,
+  author = {{U.S. General Accounting Office}},
+  title = {{NASA}: Better Mechanisms Needed for Sharing Lessons Learned},
+  institution = {U.S. General Accounting Office},
+  number = {GAO-02-195},
+  address = {Washington, DC},
+  year = {2002}
+}
+
+@article{weber2001intelligent,
+  author = {Weber, Rosina and Aha, David W. and Becerra-Fernandez, Irma},
+  title = {Intelligent Lessons Learned Systems},
+  journal = {Expert Systems with Applications},
+  volume = {20},
+  number = {1},
+  pages = {17--34},
+  year = {2001},
+  doi = {10.1016/S0957-4174(00)00046-4}
+}
+
+@book{toulmin1958uses,
+  author = {Toulmin, Stephen},
+  title = {The Uses of Argument},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  year = {1958}
+}
+
+@article{dung1995acceptability,
+  author = {Dung, Phan Minh},
+  title = {On the Acceptability of Arguments and Its Fundamental Role in Nonmonotonic Reasoning, Logic Programming and n-Person Games},
+  journal = {Artificial Intelligence},
+  volume = {77},
+  number = {2},
+  pages = {321--357},
+  year = {1995},
+  doi = {10.1016/0004-3702(94)00041-X}
+}
+
+@article{shum1994argumentation,
+  author = {Buckingham Shum, Simon and Hammond, Nick},
+  title = {Argumentation-Based Design Rationale: What Use at What Cost?},
+  journal = {International Journal of Human-Computer Studies},
+  volume = {40},
+  number = {4},
+  pages = {603--652},
+  year = {1994},
+  doi = {10.1006/ijhc.1994.1029}
+}
+
+@article{shipman1999formality,
+  author = {Shipman, Frank M. and Marshall, Catherine C.},
+  title = {Formality Considered Harmful: Experiences, Emerging Themes, and Directions on the Use of Formal Representations in Interactive Systems},
+  journal = {Computer Supported Cooperative Work},
+  volume = {8},
+  number = {4},
+  pages = {333--352},
+  year = {1999},
+  doi = {10.1023/A:1008716330212}
+}
+
+@inproceedings{gotel1994analysis,
+  author = {Gotel, Orlena C. Z. and Finkelstein, Anthony C. W.},
+  title = {An Analysis of the Requirements Traceability Problem},
+  booktitle = {Proceedings of the First International Conference on Requirements Engineering (ICRE '94)},
+  pages = {94--101},
+  year = {1994},
+  doi = {10.1109/ICRE.1994.292398}
+}
+
+@article{murphy1995software,
+  author = {Murphy, Gail C. and Notkin, David and Sullivan, Kevin},
+  title = {Software Reflexion Models: Bridging the Gap Between Source and High-Level Models},
+  journal = {ACM SIGSOFT Software Engineering Notes},
+  volume = {20},
+  number = {4},
+  pages = {18--28},
+  year = {1995},
+  doi = {10.1145/222132.222136}
+}
+
+@article{nentwich2003flexible,
+  author = {Nentwich, Christian and Capra, Licia and Emmerich, Wolfgang and Finkelstein, Anthony},
+  title = {xlinkit: A Consistency Checking and Smart Link Generation Service},
+  journal = {ACM Transactions on Internet Technology},
+  volume = {2},
+  number = {2},
+  pages = {151--185},
+  year = {2002},
+  doi = {10.1145/514183.514186}
+}
+
+@article{perry1992foundations,
+  author = {Perry, Dewayne E. and Wolf, Alexander L.},
+  title = {Foundations for the Study of Software Architecture},
+  journal = {ACM SIGSOFT Software Engineering Notes},
+  volume = {17},
+  number = {4},
+  pages = {40--52},
+  year = {1992},
+  doi = {10.1145/141874.141884}
+}
+
+@article{knuth1984literate,
+  author = {Knuth, Donald E.},
+  title = {Literate Programming},
+  journal = {The Computer Journal},
+  volume = {27},
+  number = {2},
+  pages = {97--111},
+  year = {1984},
+  doi = {10.1093/comjnl/27.2.97}
+}
+
+@inproceedings{hutchinson2011empirical,
+  author = {Hutchinson, John and Whittle, Jon and Rouncefield, Mark and Kristoffersen, Steinar},
+  title = {Empirical Assessment of {MDE} in Industry},
+  booktitle = {Proceedings of the 33rd International Conference on Software Engineering (ICSE '11)},
+  pages = {471--480},
+  year = {2011},
+  doi = {10.1145/1985793.1985858}
+}
+
+@article{hutchinson2014model,
+  author = {Hutchinson, John and Whittle, Jon and Rouncefield, Mark},
+  title = {Model-Driven Engineering Practices in Industry: Social, Organizational and Managerial Factors That Lead to Success or Failure},
+  journal = {Science of Computer Programming},
+  volume = {89},
+  pages = {144--161},
+  year = {2014},
+  doi = {10.1016/j.scico.2013.03.017}
+}
+
+@article{whittle2014state,
+  author = {Whittle, Jon and Hutchinson, John and Rouncefield, Mark},
+  title = {The State of Practice in Model-Driven Engineering},
+  journal = {IEEE Software},
+  volume = {31},
+  number = {3},
+  pages = {79--85},
+  year = {2014},
+  doi = {10.1109/MS.2013.65}
+}
+
+@article{schultz1997neural,
+  author = {Schultz, Wolfram and Dayan, Peter and Montague, P. Read},
+  title = {A Neural Substrate of Prediction and Reward},
+  journal = {Science},
+  volume = {275},
+  number = {5306},
+  pages = {1593--1599},
+  year = {1997},
+  doi = {10.1126/science.275.5306.1593}
+}
+
+@article{friston2010free,
+  author = {Friston, Karl},
+  title = {The Free-Energy Principle: A Unified Brain Theory?},
+  journal = {Nature Reviews Neuroscience},
+  volume = {11},
+  number = {2},
+  pages = {127--138},
+  year = {2010},
+  doi = {10.1038/nrn2787}
+}
+
+@article{clark2013whatever,
+  author = {Clark, Andy},
+  title = {Whatever Next? Predictive Brains, Situated Agents, and the Future of Cognitive Science},
+  journal = {Behavioral and Brain Sciences},
+  volume = {36},
+  number = {3},
+  pages = {181--204},
+  year = {2013},
+  doi = {10.1017/S0140525X12000477}
+}
+
+@book{tetlock2005expert,
+  author = {Tetlock, Philip E.},
+  title = {Expert Political Judgment: How Good Is It? How Can We Know?},
+  publisher = {Princeton University Press},
+  address = {Princeton, NJ},
+  year = {2005}
+}
+
+@book{tetlock2015superforecasting,
+  author = {Tetlock, Philip E. and Gardner, Dan},
+  title = {Superforecasting: The Art and Science of Prediction},
+  publisher = {Crown},
+  address = {New York},
+  year = {2015}
+}
+
+@article{kerr1998harking,
+  author = {Kerr, Norbert L.},
+  title = {HARKing: Hypothesizing After the Results Are Known},
+  journal = {Personality and Social Psychology Review},
+  volume = {2},
+  number = {3},
+  pages = {196--217},
+  year = {1998},
+  doi = {10.1207/s15327957pspr0203_4}
+}
+
+@article{walsh1991organizational,
+  author = {Walsh, James P. and Ungson, Gerardo Rivera},
+  title = {Organizational Memory},
+  journal = {Academy of Management Review},
+  volume = {16},
+  number = {1},
+  pages = {57--91},
+  year = {1991},
+  doi = {10.2307/258607}
+}
+
+@article{nonaka1994dynamic,
+  author = {Nonaka, Ikujiro},
+  title = {A Dynamic Theory of Organizational Knowledge Creation},
+  journal = {Organization Science},
+  volume = {5},
+  number = {1},
+  pages = {14--37},
+  year = {1994},
+  doi = {10.1287/orsc.5.1.14}
+}
+
+@incollection{wegner1987transactive,
+  author = {Wegner, Daniel M.},
+  title = {Transactive Memory: A Contemporary Analysis of the Group Mind},
+  booktitle = {Theories of Group Behavior},
+  editor = {Mullen, Brian and Goethals, George R.},
+  publisher = {Springer},
+  address = {New York},
+  pages = {185--208},
+  year = {1987},
+  doi = {10.1007/978-1-4612-4634-3_9}
+}
+
+@book{polanyi1966tacit,
+  author = {Polanyi, Michael},
+  title = {The Tacit Dimension},
+  publisher = {Doubleday},
+  address = {Garden City, NY},
+  year = {1966}
+}
+
+@book{collins2010tacit,
+  author = {Collins, Harry},
+  title = {Tacit and Explicit Knowledge},
+  publisher = {University of Chicago Press},
+  address = {Chicago},
+  year = {2010}
+}
+
+@article{cook1999bridging,
+  author = {Cook, Scott D. N. and Brown, John Seely},
+  title = {Bridging Epistemologies: The Generative Dance Between Organizational Knowledge and Organizational Knowing},
+  journal = {Organization Science},
+  volume = {10},
+  number = {4},
+  pages = {381--400},
+  year = {1999},
+  doi = {10.1287/orsc.10.4.381}
+}
+
+@book{suchman1987plans,
+  author = {Suchman, Lucy A.},
+  title = {Plans and Situated Actions: The Problem of Human-Machine Communication},
+  publisher = {Cambridge University Press},
+  address = {Cambridge, UK},
+  year = {1987}
+}
+
+@book{bowker1999sorting,
+  author = {Bowker, Geoffrey C. and Star, Susan Leigh},
+  title = {Sorting Things Out: Classification and Its Consequences},
+  publisher = {MIT Press},
+  address = {Cambridge, MA},
+  year = {1999}
+}
+
+@book{hutchins1995cognition,
+  author = {Hutchins, Edwin},
+  title = {Cognition in the Wild},
+  publisher = {MIT Press},
+  address = {Cambridge, MA},
+  year = {1995}
+}
+
+@article{clark1998extended,
+  author = {Clark, Andy and Chalmers, David},
+  title = {The Extended Mind},
+  journal = {Analysis},
+  volume = {58},
+  number = {1},
+  pages = {7--19},
+  year = {1998},
+  doi = {10.1093/analys/58.1.7}
+}
+
+@inproceedings{horvitz1999principles,
+  author = {Horvitz, Eric},
+  title = {Principles of Mixed-Initiative User Interfaces},
+  booktitle = {Proceedings of the SIGCHI Conference on Human Factors in Computing Systems (CHI '99)},
+  pages = {159--166},
+  year = {1999},
+  doi = {10.1145/302979.303030}
+}
+
+@article{bainbridge1983ironies,
+  author = {Bainbridge, Lisanne},
+  title = {Ironies of Automation},
+  journal = {Automatica},
+  volume = {19},
+  number = {6},
+  pages = {775--779},
+  year = {1983},
+  doi = {10.1016/0005-1098(83)90046-8}
+}
+
+@article{parasuraman2010complacency,
+  author = {Parasuraman, Raja and Manzey, Dietrich H.},
+  title = {Complacency and Bias in Human Use of Automation: An Attentional Integration},
+  journal = {Human Factors},
+  volume = {52},
+  number = {3},
+  pages = {381--410},
+  year = {2010},
+  doi = {10.1177/0018720810376055}
+}
+
+@techreport{moreau2013prov,
+  author = {Moreau, Luc and Missier, Paul},
+  title = {{PROV-DM}: The {PROV} Data Model},
+  institution = {World Wide Web Consortium (W3C)},
+  type = {W3C Recommendation},
+  year = {2013},
+  note = {30 April 2013}
+}
+
+@book{nato2016ajp21,
+  author = {{NATO Standardization Office}},
+  title = {{AJP-2.1}: Allied Joint Doctrine for Intelligence Procedures, Edition A, Version 1},
+  publisher = {NATO Standardization Office},
+  year = {2016}
+}
+
+@book{heuer1999psychology,
+  author = {Heuer, Richards J.},
+  title = {Psychology of Intelligence Analysis},
+  publisher = {Center for the Study of Intelligence, CIA},
+  address = {Washington, DC},
+  year = {1999}
+}
+
+@article{dhami2019analysis,
+  author = {Dhami, Mandeep K. and Belton, Ian K. and Mandel, David R.},
+  title = {The "Analysis of Competing Hypotheses" in Intelligence Analysis},
+  journal = {Applied Cognitive Psychology},
+  volume = {33},
+  number = {6},
+  pages = {1080--1090},
+  year = {2019},
+  doi = {10.1002/acp.3550}
+}
+
+@inproceedings{lewis2020retrieval,
+  author = {Lewis, Patrick and Perez, Ethan and Piktus, Aleksandra and Petroni, Fabio and Karpukhin, Vladimir and Goyal, Naman and K{\"u}ttler, Heinrich and Lewis, Mike and Yih, Wen-tau and Rockt{\"a}schel, Tim and Riedel, Sebastian and Kiela, Douwe},
+  title = {Retrieval-Augmented Generation for Knowledge-Intensive {NLP} Tasks},
+  booktitle = {Advances in Neural Information Processing Systems 33 (NeurIPS 2020)},
+  year = {2020}
+}
+
+@article{packer2023memgpt,
+  author = {Packer, Charles and Wooders, Sarah and Lin, Kevin and Fang, Vivian and Patil, Shishir G. and Stoica, Ion and Gonzalez, Joseph E.},
+  title = {{MemGPT}: Towards {LLMs} as Operating Systems},
+  journal = {arXiv preprint arXiv:2310.08560},
+  year = {2023}
+}
+
+@inproceedings{park2023generative,
+  author = {Park, Joon Sung and O'Brien, Joseph C. and Cai, Carrie J. and Morris, Meredith Ringel and Liang, Percy and Bernstein, Michael S.},
+  title = {Generative Agents: Interactive Simulacra of Human Behavior},
+  booktitle = {Proceedings of the 36th Annual ACM Symposium on User Interface Software and Technology (UIST '23)},
+  pages = {1--22},
+  year = {2023},
+  doi = {10.1145/3586183.3606763}
+}
+
+@article{anderson2004integrated,
+  author = {Anderson, John R. and Bothell, Daniel and Byrne, Michael D. and Douglass, Scott and Lebiere, Christian and Qin, Yulin},
+  title = {An Integrated Theory of the Mind},
+  journal = {Psychological Review},
+  volume = {111},
+  number = {4},
+  pages = {1036--1060},
+  year = {2004},
+  doi = {10.1037/0033-295X.111.4.1036}
+}
+
+@book{arbesman2012halflife,
+  author = {Arbesman, Samuel},
+  title = {The Half-Life of Facts: Why Everything We Know Has an Expiration Date},
+  publisher = {Current/Penguin},
+  address = {New York},
+  year = {2012}
+}
+
+@article{lenat1990cyc,
+  author = {Lenat, Douglas B. and Guha, R. V. and Pittman, Karen and Pratt, Dexter and Shepherd, Mary},
+  title = {Cyc: Toward Programs with Common Sense},
+  journal = {Communications of the ACM},
+  volume = {33},
+  number = {8},
+  pages = {30--49},
+  year = {1990},
+  doi = {10.1145/79173.79176}
+}
+
+@inproceedings{marshall2003which,
+  author = {Marshall, Catherine C. and Shipman, Frank M.},
+  title = {Which Semantic Web?},
+  booktitle = {Proceedings of the Fourteenth ACM Conference on Hypertext and Hypermedia (HT '03)},
+  pages = {57--66},
+  year = {2003},
+  doi = {10.1145/900051.900063}
+}
+
+@book{austin1996measuring,
+  author = {Austin, Robert D.},
+  title = {Measuring and Managing Performance in Organizations},
+  publisher = {Dorset House},
+  address = {New York},
+  year = {1996}
+}
+
+@article{demillo1978hints,
+  author = {DeMillo, Richard A. and Lipton, Richard J. and Sayward, Frederick G.},
+  title = {Hints on Test Data Selection: Help for the Practicing Programmer},
+  journal = {Computer},
+  volume = {11},
+  number = {4},
+  pages = {34--41},
+  year = {1978},
+  doi = {10.1109/C-M.1978.218136}
+}
+
+@article{basiri2016chaos,
+  author = {Basiri, Ali and Behnam, Niosha and de Rooij, Ruud and Hochstein, Lorin and Kosewski, Luke and Reynolds, Justin and Rosenthal, Casey},
+  title = {Chaos Engineering},
+  journal = {IEEE Software},
+  volume = {33},
+  number = {3},
+  pages = {35--41},
+  year = {2016},
+  doi = {10.1109/MS.2016.60}
+}
+
+@article{fischhoff1975hindsight,
+  author = {Fischhoff, Baruch},
+  title = {Hindsight $\neq$ Foresight: The Effect of Outcome Knowledge on Judgment Under Uncertainty},
+  journal = {Journal of Experimental Psychology: Human Perception and Performance},
+  volume = {1},
+  number = {3},
+  pages = {288--299},
+  year = {1975},
+  doi = {10.1037/0096-1523.1.3.288}
+}
+
+@book{dekker2014field,
+  author = {Dekker, Sidney},
+  title = {The Field Guide to Understanding 'Human Error'},
+  edition = {3rd},
+  publisher = {Ashgate},
+  address = {Farnham, UK},
+  year = {2014}
+}
+
+@article{maccormack2012exploring,
+  author = {MacCormack, Alan and Baldwin, Carliss and Rusnak, John},
+  title = {Exploring the Duality Between Product and Organizational Architectures: A Test of the "Mirroring" Hypothesis},
+  journal = {Research Policy},
+  volume = {41},
+  number = {8},
+  pages = {1309--1324},
+  year = {2012},
+  doi = {10.1016/j.respol.2012.04.011}
+}
+
+@inproceedings{nagappan2008influence,
+  author = {Nagappan, Nachiappan and Murphy, Brendan and Basili, Victor R.},
+  title = {The Influence of Organizational Structure on Software Quality: An Empirical Case Study},
+  booktitle = {Proceedings of the 30th International Conference on Software Engineering (ICSE '08)},
+  pages = {521--530},
+  year = {2008},
+  doi = {10.1145/1368088.1368160}
+}
+
+@article{carlile2004transferring,
+  author = {Carlile, Paul R.},
+  title = {Transferring, Translating, and Transforming: An Integrative Framework for Managing Knowledge Across Boundaries},
+  journal = {Organization Science},
+  volume = {15},
+  number = {5},
+  pages = {555--568},
+  year = {2004},
+  doi = {10.1287/orsc.1040.0094}
+}
+
+@article{carlile2002pragmatic,
+  author = {Carlile, Paul R.},
+  title = {A Pragmatic View of Knowledge and Boundaries: Boundary Objects in New Product Development},
+  journal = {Organization Science},
+  volume = {13},
+  number = {4},
+  pages = {442--455},
+  year = {2002},
+  doi = {10.1287/orsc.13.4.442.2953}
+}
+```

--- a/docs/kos-roadmap-v3.md
+++ b/docs/kos-roadmap-v3.md
@@ -1,0 +1,538 @@
+# KOS Roadmap v3 — Literature-Hardened Edition
+
+> Supersedes roadmap v2. Integrates three inputs: (1) the v2 primary-source
+> assessment of the repo, (2) the nine beyond-vision improvements, (3) the
+> literature survey's failure-mode findings across design rationale,
+> traceability, KM, MDE, Semantic Web, and lessons-learned systems.
+>
+> Organizing principle, drawn from the survey's central lesson: **every
+> knowledge-capture system in the literature died from the same wound —
+> asymmetric cost/benefit [@grudin1996evaluating]. The people who pay the
+> capture cost are not the people who reap the retrieval benefit.** KOS
+> survives only if every milestone either reduces capture cost, increases
+> retrieval benefit, or moves benefit to the moment of capture. Items that
+> do none of these are cut or deferred, regardless of intellectual appeal.
+
+---
+
+## Part 0 — What the literature changed
+
+Five findings that reshaped the roadmap's structure:
+
+**L1. The Grudin asymmetry is the master risk.** Design rationale capture
+(gIBIS/QOC) failed on intrusiveness and deferred benefit
+[@grudin1996evaluating; @shipman1997design]. Traceability fails the same
+way — links decay because maintainers pay and downstream readers benefit
+[@gotel1994analysis; @arkley2005overcoming]. KM initiatives died on
+incentive misalignment [@walsh1991organizational]. **Roadmap consequence:**
+every issue below is tagged with its cost/benefit posture; a new Milestone
+R (Retrieval-first) is promoted ahead of most capture discipline.
+
+**L2. Reflexion models, not full traceability.** Murphy & Notkin's
+Reflexion approach succeeded where DOORS-class traceability failed by
+checking a *lightweight declared model against extracted reality* and
+reporting only divergences [@murphy1995software]. This is exactly what
+`kos drift` + seam detection already do. **Consequence:** the
+correspondence layer ambition is re-scoped from "maintain typed spec↔code
+links" (the DOORS death march) to "declare little, extract much, report
+divergence" — cheaper and validated by prior success.
+
+**L3. The graveyard is the genuinely novel contribution.** Lessons-learned
+systems failed on retrieval-at-need, not on capture — NASA's LLIS
+accumulated entries nobody consulted at decision time [@weber2001intelligent].
+No prior system combines append-only negative knowledge with typed
+*reopener* conditions checked mechanically. **Consequence:** graveyard
+research is elevated from hygiene chore to the project's flagship claim,
+with reopener-triggering as the differentiator (Issue 24).
+
+**L4. Confidence half-life has an existing formalization.** ACT-R
+base-level activation already models memory decay with retrieval-frequency
+reinforcement [@anderson1991reflections]. Don't invent decay curves —
+adopt the rational-analysis form. **Consequence:** Improvement #3 gains a
+concrete mechanism and loses its "arbitrary horizons" risk.
+
+**L5. Goodhart applies to KOS's own metrics.** Measurement dysfunction
+literature [@austin1996measuring] predicts that node counts, finding
+counts, and calibration scores will be gamed the moment they carry status.
+**Consequence:** all process metrics become *diagnostic* (visible in
+reports, never in gates), and canary detection-rate becomes the only
+health metric that resists gaming — you can't game detection of
+corruption you don't know exists.
+
+---
+
+## Part 1 — Milestone structure (revised)
+
+```
+M0  Repair & Truth          (unchanged from v2, 3 issues)
+M1  Enforcement Inversion   (unchanged core, +instrument tests)
+MR  Retrieval-First         (NEW — promoted above old M2; Grudin's cure)
+M2  Query & Context         (absorbed into MR where overlapping)
+M3  Science                 (rebuilt around literature-validated methods)
+M4  Substrate               (gated, unchanged)
+M5  Mission & Positioning   (expanded: publishable claims identified)
+```
+
+The single largest change: **retrieval before discipline.** v2 sequenced
+gates → repairs → queries. The literature says systems die when capture
+discipline arrives before retrieval value [@grudin1996evaluating;
+@marshall2003semantic]. Gates stay early only where they are *zero-cost to
+authors* (CI validation catches what authors never see); everything that
+taxes the author at write time moves after retrieval proves its worth.
+
+---
+
+## Part 2 — Issues
+
+### M0 — Repair & Truth (v2 issues 1, 2, 19 stand)
+
+Unchanged. Schema drift repair (observation edges, graveyard type
+conflation, dangling founding refs), charter-content classification, and
+the README truth pass. One addition to Issue 1:
+
+**Issue 1 addendum — rename maps become migration infrastructure.**
+Ontology-evolution literature shows identity churn is the norm, not an
+incident [@noy2004ontology]. The one-time rename map becomes
+`_kos/migrations/` with a `kos migrate` stub — schema v0.4 ships with the
+migration path it will need, not after the next breakage.
+*Cost/benefit: author-neutral, system-paid.*
+
+---
+
+### M1 — Enforcement Inversion (v2 issues 4, 18 stand; 5, 6 modified)
+
+**Issue 4 (unchanged, still first):** full-scope validate, CI job,
+pre-commit hook, dangling targets = error. This is Grudin-safe: the
+machine pays, authors only see failures they caused.
+*Cost/benefit: author-neutral.*
+
+**Issue 18 (unchanged):** test the instrument (validate/model/drift/charter
+≥20 tests). The validator must be more trustworthy than the graph it
+judges.
+
+**Issue 5 (modified — measure only):** context budget accounting ships;
+the *pruning* of imports waits for MR telemetry (Issue 20) to show what's
+actually read. Cutting before measuring repeats the KM pattern of
+optimizing unobserved behavior.
+
+**Issue 6 (modified — softened per Goodhart):** the artifact-close rule
+becomes a *dashboard signal* (sessions closed with/without artifacts,
+visible in `kos doctor`), not a hard gate. Austin's measurement-dysfunction
+finding [@austin1996measuring]: gate it and sessions will produce
+token commits to satisfy the gate. Surface it and let the human pawl
+judge. Two consecutive analysis-only sessions still trigger the mandatory
+graveyard review — that part is judgment-preserving.
+
+---
+
+### MR — Retrieval-First (NEW milestone; the Grudin cure)
+
+The survey's verdict: capture systems survive only when retrieval benefit
+arrives *before* capture discipline is demanded. Everything here increases
+what the graph gives back per token of authoring already spent.
+
+**Issue 20: Retrieval telemetry (Improvement #7, promoted).**
+`_kos/.telemetry/reads.jsonl` logging node IDs served by orient/query/
+doctor. Ten-session baseline. Hypothesis pre-registered: retrieval follows
+a power law; ≥40% of nodes never read post-creation. This is the
+instrument every later cost/benefit decision depends on — the metric
+Walsh & Ungson's organizational-memory program never had
+[@walsh1991organizational].
+*Cost/benefit: author-neutral; produces the benefit ledger.*
+**Deeper-treatment flag from survey honored: this is the empirical core.**
+
+**Issue 21: Subgraph context format + query commands (v2 issues 7+8
+merged).** Unchanged in content; re-justified by the survey: this is the
+"retrieval at the moment of need" that LLIS lacked [@weber2001intelligent].
+Format spec first, three hand-built ThreeDoors examples, then
+frontier/bedrock/recent commands emitting it.
+
+**Issue 22: Task-conditional orient (v2 issue 9).** Unchanged. The
+empirical test of charter-as-cache. Token cost measured against full
+charter load; either outcome is a finding.
+
+**Issue 23: MCP server (Improvement #8, promoted into MR).** Read-only
+epistemic API serving the Issue-21 format. Rationale upgraded by the
+survey: mixed-initiative literature [@horvitz1999principles] and the
+platform's own F10 failure mode both say the benefit must arrive *inside
+the agent's task loop*, not in a separate consultation step. Gated on 21.
+*Cost/benefit: pure retrieval-side; zero author tax.*
+
+**Issue 24: Reopener triggers — the graveyard's differentiator (NEW).**
+Graveyard reopeners are currently prose. Make them machine-checkable:
+structured `trigger` conditions (dependency-hash change, date horizon,
+external-fact assertion) evaluated by `kos stale`. When a trigger fires,
+the graveyard entry surfaces in orient output. This is the feature no
+lessons-learned system ever shipped — negative knowledge that *re-presents
+itself at the moment it becomes relevant* [@weber2001intelligent]. Flagged
+by the survey as the project's most publishable novelty; treat
+accordingly.
+*Cost/benefit: small structured-authoring cost at graveyard time (already
+the cheapest moment — the finding is fresh), large deferred retrieval
+benefit delivered automatically.*
+
+---
+
+### M3 — Science (rebuilt)
+
+Ordering within M3 now follows credibility-per-effort from the survey.
+
+**Issue 25: Retrodiction engine (Improvement #5, promoted to first
+science item).** `kos asof <ref>` + historical seam replay on the four
+ThreeDoors incidents, operator blinded to incident selection, prediction
+registered before running (≥2 of 4 detectable at T-minus-one-sprint).
+Survey hardening: adopt backtesting hygiene against look-ahead bias
+[@bailey2014pseudo] and hindsight-bias controls from accident-investigation
+methodology [@fischhoff1975hindsight; @dekker2002field] — the blinding
+protocol is not optional, it is the experiment.
+*This is the project's highest-credibility experiment and its best paper.*
+
+**Issue 10 (v2, corrected premise stands): calibration pipeline.**
+Survey addition: adopt Brier scoring and the forecasting-literature
+apparatus wholesale [@tetlock2015superforecasting; @brier1950verification]
+rather than inventing surprise taxonomies. `surprise_magnitude` maps to
+calibration-curve residuals. Pre-registration framing now cites the
+registered-reports model [@nosek2014registered] — briefs *are* registered
+reports for engineering knowledge; say so in the docs and inherit the
+discipline's norms (no post-hoc hypothesis editing, `post_hoc: true` flag
+for probe-null findings, HARKing named as the failure mode [@kerr1998harking]).
+
+**Issue 11 (v2 stands): controlled baseline** — naive LLM-over-docs vs.
+graph, finding-023 rubric, two projects. Unchanged.
+
+**Issue 17 (v2 stands, sharpened): typed-edge thesis test.** Survey
+sharpening: the 92%-derives monoculture mirrors the Semantic Web's
+ontology-cost failure — rich taxonomies go unused because authors default
+to the cheapest link [@marshall2003semantic; @shipman1999formality].
+The probe now tests Shipman & Marshall's "formality tax" hypothesis
+directly: retype 50 edges, measure traversal value, and *also* measure
+authoring cost per typed edge. If value < cost, prune the taxonomy to
+derives/contradicts/supersedes and treat that as confirmation of the
+incremental-formalization literature, not defeat.
+
+**Issue 26: Canary nodes (Improvement #2, admitted to M3).**
+Epistemic mutation testing [@demillo1978hints] + chaos-engineering framing
+[@basiri2016chaos]. Three canaries across tiers, sealed hash-committed
+registration, five normal sessions, reveal. Goodhart-resistant health
+metric per L5. Hawthorne mitigation: random delays, low base rate.
+
+**Issue 12, 13, 14 (v2 stand):** inter-rater reliability (Cohen's kappa on
+30-finding sample), external-operator probe (now trivially runnable via
+Issue 23's MCP endpoint — dependency updated), scheduled graveyard audit
+every 3 sessions with the 10-session sunset rule.
+
+**Deferred from the nine improvements, with reasons:**
+- *Source Reliability Ledger (#1):* n-of-sources too small until the
+  platform has more operators; also Goodhart-exposed (grades become
+  status). Revisit when ≥4 distinct sustained sources exist. The Admiralty
+  two-axis insight (source vs. information) is adopted *conceptually* now:
+  provenance and confidence stay separate fields, never merged.
+- *Confidence half-life (#3):* adopt ACT-R base-level form per L4, but
+  implement only after Issue 20's telemetry exists — decay reinforced by
+  retrieval requires retrieval counts. Sequenced behind MR by construction.
+- *Dissent nodes (#6):* premature at one human; parked with a trigger —
+  reopens when a second sustained human operator joins.
+- *Toulmin fields (#4):* survey warning is direct — argumentation
+  formalisms are the canonical Grudin victim [@shipman1997design;
+  @conklin1988gibis]. Admit only the single cheapest field:
+  `rebuttal_conditions` on bedrock (it doubles as Issue 24's trigger
+  vocabulary). Grounds/warrant structure stays graveyarded until someone
+  demonstrates demand via telemetry.
+- *Chronicle (#9):* admitted as a *projection* (read-side, Grudin-safe)
+  but sequenced after Issue 21's traversal machinery, which it reuses.
+  Becomes Issue 27, M5-adjacent, paired with the external-operator probe
+  as its comprehension benchmark.
+
+---
+
+### M4 — Substrate (v2 issue 15 stands, gated on M0–MR)
+
+One survey addition: the MDE failure literature [@whittle2014state;
+@hutchinson2011empirical] is the checklist for any substrate migration —
+tool lock-in, round-trip breakage, and skill asymmetry killed MDE in
+industry. Each substrate probe's brief must state its answer to all three
+before the probe runs.
+
+---
+
+### M5 — Mission & Positioning (expanded)
+
+**Issue 16 (v2 stands):** mission split; graveyard
+continuity-via-infrastructure with model-level reopener.
+
+**Issue 28: Publishable claims register (NEW).** The survey identifies
+where KOS sits: CSCW/CHI (human-AI knowledge work), ICSE/FSE (drift and
+seam detection), and the emerging LLM-agent-memory literature. Three
+claims are paper-shaped once their issues close:
+(a) *Retrodictive seam detection* — Issue 25's blinded replay result;
+(b) *Reopener-triggered negative knowledge* — Issue 24, positioned against
+the lessons-learned failure literature;
+(c) *Calibrated engineering hypotheses* — Issue 10 at n≥30, positioned as
+registered reports for design decisions.
+The register tracks each claim's evidentiary status; nothing is drafted
+until its evidence closes. This converts "improve rigor" from aspiration
+into named, falsifiable, externally-judgeable outputs.
+
+---
+
+## Part 3 — Sequencing
+
+```
+n:    Issue 4 (gate on) ── failures enumerate the M0 worklist
+n+1:  Issues 1(+migrations), 19
+n+2:  Issues 2, 3 (charter classification, cutover)
+n+3:  Issues 18, 5(measure-only), 20 (telemetry starts NOW — 10-session clock)
+n+4:  Issue 21 (format + queries)
+n+5:  Issues 22, 24 (task-orient; reopener triggers)
+n+6:  Issue 23 (MCP), Issue 14 first graveyard audit
+n+7:  Issue 25 (retrodiction — the flagship experiment)
+then: 10, 11, 17, 26 as the science block · 12, 13 · 27 · 15 gated · 16, 28
+```
+
+Standing rules, now three:
+1. **Each issue closes with a commit** (unchanged).
+2. **No new author-side capture requirement ships before MR demonstrates
+   retrieval value** — the Grudin rule, enforced by milestone ordering.
+3. **Process metrics are diagnostic, never gates** — the Goodhart rule.
+   The only gated checks are machine-payable (schema, hashes, dangling
+   refs).
+
+---
+
+## Part 4 — What v3 removes from consideration entirely
+
+Named cuts, with the literature that killed them:
+
+- **Full spec↔code traceability matrices** — DOORS-class maintenance decay
+  [@gotel1994analysis; @arkley2005overcoming]. Reflexion-style divergence
+  reporting only [@murphy1995software].
+- **Rich argumentation ontologies** — gIBIS/QOC intrusiveness
+  [@conklin1988gibis; @shipman1997design]. One field survives
+  (`rebuttal_conditions`).
+- **Comprehensive upfront ontology work on edge types** — Semantic Web
+  authoring-cost failure [@marshall2003semantic]. Taxonomy earns each type
+  via Issue 17 or loses it.
+- **Auto-summarization of the charter or nodes** — "industrialized
+  forgetting"; also the round-trip failure MDE documented
+  [@hutchinson2011empirical]. Projections are authored or deterministic,
+  never lossy-automatic.
+- **Gamified process metrics** (node counts, finding velocity, coverage
+  percentages as targets) — Goodhart/Austin [@austin1996measuring].
+
+---
+
+## Bibliography
+
+```bibtex
+@article{grudin1996evaluating,
+  author = {Grudin, Jonathan},
+  title = {Evaluating Opportunities for Design Capture},
+  journal = {Design Rationale: Concepts, Techniques, and Use},
+  publisher = {Lawrence Erlbaum},
+  year = {1996},
+  pages = {453--470}
+}
+@article{shipman1997design,
+  author = {Shipman, Frank M. and McCall, Raymond J.},
+  title = {Integrating Different Perspectives on Design Rationale: Supporting the Emergence of Design Rationale from Design Communication},
+  journal = {Artificial Intelligence for Engineering Design, Analysis and Manufacturing},
+  volume = {11},
+  number = {2},
+  year = {1997},
+  pages = {141--154}
+}
+@article{gotel1994analysis,
+  author = {Gotel, Orlena C. Z. and Finkelstein, Anthony C. W.},
+  title = {An Analysis of the Requirements Traceability Problem},
+  journal = {Proceedings of the First International Conference on Requirements Engineering},
+  year = {1994},
+  pages = {94--101}
+}
+@inproceedings{arkley2005overcoming,
+  author = {Arkley, Paul and Riddle, Steve},
+  title = {Overcoming the Traceability Benefit Problem},
+  booktitle = {13th IEEE International Conference on Requirements Engineering},
+  year = {2005},
+  pages = {385--389}
+}
+@article{murphy1995software,
+  author = {Murphy, Gail C. and Notkin, David and Sullivan, Kevin},
+  title = {Software Reflexion Models: Bridging the Gap between Source and High-Level Models},
+  journal = {ACM SIGSOFT Software Engineering Notes},
+  volume = {20},
+  number = {4},
+  year = {1995},
+  pages = {18--28}
+}
+@article{walsh1991organizational,
+  author = {Walsh, James P. and Ungson, Gerardo Rivera},
+  title = {Organizational Memory},
+  journal = {Academy of Management Review},
+  volume = {16},
+  number = {1},
+  year = {1991},
+  pages = {57--91}
+}
+@article{weber2001intelligent,
+  author = {Weber, Rosina and Aha, David W. and Becerra-Fernandez, Irma},
+  title = {Intelligent Lessons Learned Systems},
+  journal = {Expert Systems with Applications},
+  volume = {20},
+  number = {1},
+  year = {2001},
+  pages = {17--34}
+}
+@article{anderson1991reflections,
+  author = {Anderson, John R. and Schooler, Lael J.},
+  title = {Reflections of the Environment in Memory},
+  journal = {Psychological Science},
+  volume = {2},
+  number = {6},
+  year = {1991},
+  pages = {396--408}
+}
+@book{austin1996measuring,
+  author = {Austin, Robert D.},
+  title = {Measuring and Managing Performance in Organizations},
+  publisher = {Dorset House},
+  year = {1996}
+}
+@inproceedings{horvitz1999principles,
+  author = {Horvitz, Eric},
+  title = {Principles of Mixed-Initiative User Interfaces},
+  booktitle = {Proceedings of the SIGCHI Conference on Human Factors in Computing Systems},
+  year = {1999},
+  pages = {159--166}
+}
+@article{marshall2003semantic,
+  author = {Marshall, Catherine C. and Shipman, Frank M.},
+  title = {Which Semantic Web?},
+  journal = {Proceedings of the Fourteenth ACM Conference on Hypertext and Hypermedia},
+  year = {2003},
+  pages = {57--66}
+}
+@article{shipman1999formality,
+  author = {Shipman, Frank M. and Marshall, Catherine C.},
+  title = {Formality Considered Harmful: Experiences, Emerging Themes, and Directions on the Use of Formal Representations in Interactive Systems},
+  journal = {Computer Supported Cooperative Work},
+  volume = {8},
+  number = {4},
+  year = {1999},
+  pages = {333--352}
+}
+@inproceedings{conklin1988gibis,
+  author = {Conklin, Jeff and Begeman, Michael L.},
+  title = {gIBIS: A Hypertext Tool for Exploratory Policy Discussion},
+  booktitle = {Proceedings of the 1988 ACM Conference on Computer-Supported Cooperative Work},
+  year = {1988},
+  pages = {140--152}
+}
+@article{fischhoff1975hindsight,
+  author = {Fischhoff, Baruch},
+  title = {Hindsight Is Not Equal to Foresight: The Effect of Outcome Knowledge on Judgment under Uncertainty},
+  journal = {Journal of Experimental Psychology: Human Perception and Performance},
+  volume = {1},
+  number = {3},
+  year = {1975},
+  pages = {288--299}
+}
+@book{dekker2002field,
+  author = {Dekker, Sidney},
+  title = {The Field Guide to Human Error Investigations},
+  publisher = {Ashgate},
+  year = {2002}
+}
+@article{bailey2014pseudo,
+  author = {Bailey, David H. and Borwein, Jonathan M. and L{\'o}pez de Prado, Marcos and Zhu, Qiji Jim},
+  title = {Pseudo-Mathematics and Financial Charlatanism: The Effects of Backtest Overfitting on Out-of-Sample Performance},
+  journal = {Notices of the AMS},
+  volume = {61},
+  number = {5},
+  year = {2014},
+  pages = {458--471}
+}
+@book{tetlock2015superforecasting,
+  author = {Tetlock, Philip E. and Gardner, Dan},
+  title = {Superforecasting: The Art and Science of Prediction},
+  publisher = {Crown},
+  year = {2015}
+}
+@article{brier1950verification,
+  author = {Brier, Glenn W.},
+  title = {Verification of Forecasts Expressed in Terms of Probability},
+  journal = {Monthly Weather Review},
+  volume = {78},
+  number = {1},
+  year = {1950},
+  pages = {1--3}
+}
+@article{nosek2014registered,
+  author = {Nosek, Brian A. and Lakens, Dani{\"e}l},
+  title = {Registered Reports: A Method to Increase the Credibility of Published Results},
+  journal = {Social Psychology},
+  volume = {45},
+  number = {3},
+  year = {2014},
+  pages = {137--141}
+}
+@article{kerr1998harking,
+  author = {Kerr, Norbert L.},
+  title = {HARKing: Hypothesizing After the Results Are Known},
+  journal = {Personality and Social Psychology Review},
+  volume = {2},
+  number = {3},
+  year = {1998},
+  pages = {196--217}
+}
+@article{demillo1978hints,
+  author = {DeMillo, Richard A. and Lipton, Richard J. and Sayward, Frederick G.},
+  title = {Hints on Test Data Selection: Help for the Practicing Programmer},
+  journal = {Computer},
+  volume = {11},
+  number = {4},
+  year = {1978},
+  pages = {34--41}
+}
+@article{basiri2016chaos,
+  author = {Basiri, Ali and Behnam, Niosha and de Rooij, Ruud and Hochstein, Lorin and Kosewski, Luke and Reynolds, Justin and Rosenthal, Casey},
+  title = {Chaos Engineering},
+  journal = {IEEE Software},
+  volume = {33},
+  number = {3},
+  year = {2016},
+  pages = {35--41}
+}
+@article{whittle2014state,
+  author = {Whittle, Jon and Hutchinson, John and Rouncefield, Mark},
+  title = {The State of Practice in Model-Driven Engineering},
+  journal = {IEEE Software},
+  volume = {31},
+  number = {3},
+  year = {2014},
+  pages = {79--85}
+}
+@inproceedings{hutchinson2011empirical,
+  author = {Hutchinson, John and Whittle, Jon and Rouncefield, Mark and Kristoffersen, Steinar},
+  title = {Empirical Assessment of MDE in Industry},
+  booktitle = {Proceedings of the 33rd International Conference on Software Engineering},
+  year = {2011},
+  pages = {471--480}
+}
+@article{noy2004ontology,
+  author = {Noy, Natalya F. and Klein, Michel},
+  title = {Ontology Evolution: Not the Same as Schema Evolution},
+  journal = {Knowledge and Information Systems},
+  volume = {6},
+  number = {4},
+  year = {2004},
+  pages = {428--440}
+}
+```
+
+---
+
+*v3 verdict in one line: the literature's graveyard is now KOS's map —
+retrieval before discipline, divergence-reporting before traceability,
+machine-payable gates only, and three named experiments (retrodiction,
+reopener triggers, calibrated briefs) that no prior system ran and this
+one can.*

--- a/docs/kos-roadmap-v3_1.md
+++ b/docs/kos-roadmap-v3_1.md
@@ -1,0 +1,153 @@
+# KOS Roadmap v3.1 — Operability Fold
+
+> Delta document. v3 (literature-hardened) remains the base; v3.1 folds
+> the use assessment's fourteen recommendations (R1–R14,
+> `kos-use-assessment.md`) into the milestone structure. Unchanged v3
+> issues are not restated. The standing rules gain a fourth.
+>
+> Placement logic: every R-item is machine-paid or confirm-only, so all
+> pass the Grudin rule by construction. They slot as (a) extensions to
+> existing issues, (b) three new issues, (c) one new sub-milestone.
+
+---
+
+## Standing rules (rule 4 added)
+
+1. Each issue closes with a commit.
+2. No new author-side capture requirement ships before MR demonstrates
+   retrieval value (Grudin rule).
+3. Process metrics are diagnostic, never gates (Goodhart rule).
+4. **The tool drives the process; the operator makes the decisions
+   (Bainbridge rule).** Automation of reminding, scheduling, checking,
+   and proposing is encouraged; automation of judging (promotion,
+   meaning, dissent) is prohibited. Every automated proposal is
+   confirm-or-override.
+
+---
+
+## Fold map — R-items into the v3 structure
+
+### Into M1 (Enforcement Inversion)
+
+**Issue 4 extended (validate gate) ← R4.**
+Fail-at-authorship absorbed: unknown edge types and dangling targets
+reject at commit (already in v3); *add* creation-time interrogation —
+`kos finding` prompts "which brief? [none → post_hoc: true]",
+`kos probe` prompts for `predicted_confidence`. The schema is taught at
+the point of use, not memorized.
+
+**Issue 18 extended (instrument tests) ← R1 dependency.**
+Status-machine state derivation (open briefs, unharvested findings,
+unmoved tiers) gets test fixtures alongside validate/model/drift/charter.
+
+**NEW Issue 29: `kos status` — the cycle state machine (R1, R6).**
+Reads workspace state and answers "where am I; what's the next verb":
+open loops, obligations, fired reopener triggers, dirty dependents,
+stale frontier. Nothing enforced, everything surfaced. Replaces
+"read the charter" as the session entry ritual in CLAUDE.md; `orient` is
+what status recommends on cold context. R6 rides on it once Issue 24's
+triggers exist: the graph opens the session.
+*AC: one command; session protocol updated; a seeded fixture workspace
+with three known open loops yields exactly those three obligations.*
+
+**NEW Issue 30: Ritual hooks (R2, R5).**
+Session-start hook → status; post-harvest → charter render;
+every-Nth-session → graveyard-audit and staleness prompts (feeds v3
+Issue 14's cadence); pre-commit soft prompts for missing predictor
+fields. R5's scale profiles: `kos cycle start --scale=probe|feature|fix`
+sets the expectation profile status checks against — fix-scale work is
+never nagged about briefs.
+*AC: hooks installed via lefthook/CLAUDE.md; cadence prompts fire on a
+fixture; scale profile suppresses/raises expectations correctly.*
+
+### Into MR (Retrieval-First)
+
+**Issue 20 extended (telemetry) ← R10 input.**
+Reads.jsonl additionally timestamps per-repo graph-touch, enabling the
+decay signature (graph frozen while git moves).
+
+**Issue 23 extended (MCP server) ← R13.**
+Adds the write-side complement: `_kos/inbox/` for agent-emitted candidate
+observations, triaged by the human at harvest. Agents query; agents
+propose; agents never write nodes. Proposal ≠ promotion. The inbox is
+also the landing zone for multi-topic-source extraction (universal-bridge
+problem) — unplaced observations go to triage, not to loss.
+*AC addition: a foreign agent files an observation via MCP; it appears in
+inbox; `kos status` surfaces it; promotion requires human action.*
+
+**NEW Issue 31: `kos capture` — cheap node creation (R3).**
+One interactive command: sentence in → proposed id/type/tier/edges as
+confirm-or-override defaults → valid node out. LLM-assisted drafting
+permitted; every field human-confirmed. Attacks the charter-inflation
+vacuum at its source: closes the 10-second-prose vs. 3-minute-node gap.
+*Cost posture: author-light, confirm-only — MR-eligible under rule 2
+because it reduces capture cost rather than adding capture duty.*
+*AC: capture-to-committed-valid-node under 30 seconds on a fixture;
+telemetry (Issue 20) later tests whether captured nodes are ever read.*
+
+### NEW sub-milestone MO (Onboarding & Fleet) — after MR core, before M3
+
+Rationale: adopt/census depend on capture (31), status (29), and the
+two-lens findings; they precede the science block because Issues 11/13
+(baseline, external operator) need cheap onboarding to run at all.
+
+**NEW Issue 32: `kos adopt <path>` (R7) + onboarding levels (R8).**
+One verb replacing init+manual-seed: inventory (docs, code, git,
+CLAUDE.md, .claude/, BMAD, ADRs) → lens-classified seed plan → 
+confirm-or-override node proposals via the capture path. Implements
+seed = sync-maximally-behind as a command instead of prose bedrock.
+Levels land in `_kos/kos.yaml`: `tracked | seeded | active`; doctor and
+status scale expectations to level; the fourth topology
+(orc-without-kos) gets a decision, not a shrug.
+*AC: adopt on one real BMAD-born repo yields a reviewed seed of ≥10
+nodes with zero hand-written YAML; finding-016's both-lenses requirement
+enforced by the plan prompt; level recorded and respected by doctor.*
+
+**NEW Issue 33: Fleet census + vital signs (R9, R10) + coexistence
+registry (R12, R14).**
+`kos graphs --census`: per-repo rows — onboarded?, level, last graph
+touch, open loops, validate status, drift count, decay signature.
+Not-onboarded repos are rows, not absences. Vital signs are liveness
+only (Goodhart rule): schema-valid %, dangling edges, unaddressed fired
+reopeners, charter/graph render-diff, graph-frozen-while-git-moves.
+`_kos/coexistence.yaml` declares system boundaries (tasks→bd,
+sessions→multiclaude, pipeline-state→factory, specs→BMAD/spectacle) and
+seam-scan inputs; doctor flags boundary violations as a signal class;
+cross-system contradictions enter seam detection as first-class input
+(R14). R11 (observe, never migrate) is recorded as a design value node,
+not an issue — it constrains all adapters.
+*AC: census runs from orc session-start hook; one deliberately decayed
+fixture repo is flagged by signature alone; one boundary violation
+(task-shaped frontier node) is caught by doctor.*
+
+### Into M3 (Science) — dependency updates only
+
+Issue 13 (external operator): now runs against Issue 32's adopt +
+Issue 23's MCP endpoint — the probe cost drops from "coach a stranger
+through expert ceremony" to "hand them two commands," which is itself
+the measurement.
+Issue 26 (canaries): census (33) becomes the reveal surface — an
+undetected canary is a vital-signs miss, sharpening what the health
+metric means.
+
+---
+
+## Revised sequencing (v3 base, deltas bolded)
+
+```
+n:     Issue 4(+R4 prompts) — gate on
+n+1:   Issues 1, 19
+n+2:   Issues 2, 3
+n+3:   Issues 18(+state fixtures), 5, 20(+touch-telemetry)
+n+4:   **Issue 29 (status)**, Issue 21
+n+5:   **Issues 30 (hooks), 31 (capture)**, Issue 22
+n+6:   Issue 23(+**inbox**), Issue 24, Issue 14 (now hook-prompted)
+n+7:   **Issue 32 (adopt+levels)** — first real BMAD repo onboarded
+n+8:   **Issue 33 (census+coexistence)**, Issue 25 (retrodiction)
+then:  10, 11, 17, 26 · 12, 13(cheapened) · 27 · 15 gated · 16, 28
+```
+
+Net effect on the operator, stated once: fifteen memorized duties become
+one habit (`kos status`), two confirm-flows (`capture`, `adopt`), and a
+set of prompts that arrive when due. The judgments — promotion, meaning,
+dissent — remain exactly where the SOUL put them.

--- a/docs/kos-use-assessment.md
+++ b/docs/kos-use-assessment.md
@@ -1,0 +1,232 @@
+# KOS Use Assessment — Operator Burden, Onboarding, Detection, Coexistence
+
+> Assessment of how KOS is actually operated: the unguided cycle within a
+> typical Claude session, onboarding of new repos, detection of
+> not-onboarded and not-working states, and coexistence with parallel
+> systems (bd/beads, multiclaude, gastown-class orchestrators,
+> vsdd-factory pipelines, BMAD). Goal: recommendations that make KOS more
+> reliable, more automatic, and less dependent on expert knowledge —
+> within the SOUL constraints (no auto-summarization, no silent rewriting,
+> human remains the pawl on promotion, uncertainty stays explicit).
+
+---
+
+## Part 1 — The operator's current burden
+
+Reconstructed from CLAUDE.md, the CLI surface, and observed session
+history, one full cycle requires roughly **fifteen distinct expert
+judgments**, all voluntary, all invisible when skipped:
+
+1. **Session start:** know to read the charter or run `kos orient`; know
+   which directory/topology to launch from (finding-037 F4 — undefined
+   for subrepos and standalone repos).
+2. **Cycle discipline:** begin with a question; write a brief *before*
+   probing; set `predicted_confidence` at brief time (1 of 25 briefs did).
+3. **During work:** judge when an insight becomes a node vs. charter
+   prose vs. nothing; pick among 8 edge types; pick a confidence tier;
+   follow the id-naming grammar.
+4. **Harvest:** remember the checklist; write the finding with
+   `surprise_magnitude`; update affected nodes; move files between tiers;
+   regenerate the charter; use the commit vocabulary.
+5. **Periodically:** graveyard audits, staleness review, validation —
+   none scheduled, none prompted.
+6. **Repair:** notice drift/breakage unaided — nothing fires; CI ignores
+   `_kos/**`.
+
+## Part 2 — The fragility diagnosis
+
+The evidence says skipping is the norm: 19% of findings have no brief;
+92% of edges default to `derives`; the predictor fields sat unused; the
+harvest checklist was added *because* steps were skipped, and steps were
+skipped after; the charter re-inflated through three compressions; 11 orc
+nodes and 15 kos probe-nodes drifted silently.
+
+The pattern is named in the project's own bedrock —
+**`elem-gate-enforcement`: instruction-based enforcement fails;
+infrastructure enforcement works.** KOS today is an instruction-based
+system whose own author's compliance is visibly partial. For any second
+operator it is an expert instrument with no guardrails: cost of correct
+use is high, cost of incorrect use is invisible, benefit is deferred —
+Grudin's asymmetry expressed as UX.
+
+A second fragility: **the cycle has no clock.** Orient → Ideate →
+Question → Probe → Harvest → Promote is a loop with no mechanism that
+knows where in the loop you are. Open briefs, unharvested findings, and
+unmoved tiers exist in the files, but nothing reads the state back as
+obligation. Every transition depends on the human remembering the next
+verb.
+
+## Part 3 — Recommendations: from recorder to partner
+
+The inversion in one line: **today the operator drives the process and
+the tool records; the fix is the tool drives the process and the operator
+makes the decisions.** All items below are prompting, defaulting, and
+machine-paid checking — never automated judgment.
+
+### R1. Give the cycle a state machine — `kos status` as the spine
+The workspace already encodes cycle state implicitly (briefs without
+findings, findings without promotions, dirty dependents, stale frontier,
+fired triggers). One command reads it and answers *"where am I and what
+is the next verb?"* Nothing enforced; everything surfaced. `kos status`
+replaces "read the charter" as the session entry ritual; orient becomes
+what status recommends when context is cold. Fifteen memorized duties
+collapse into one habit.
+
+### R2. Hooks fire the rituals; humans perform them
+Session-start hook → `kos status`. Pre-commit → validate plus soft
+prompts ("finding lacks `surprise_magnitude` — proceed? [y/n]").
+Post-harvest → charter render. Every-Nth-session → graveyard-audit and
+staleness prompts. The human never remembers a cadence again; the human
+only answers prompts. Bainbridge-safe: automate *reminding*, never
+*judging*.
+
+### R3. Make node creation cheaper than prose
+The charter inflates because a paragraph costs 10 seconds and a node
+costs 3 minutes. `kos capture`: one interactive command that takes a
+sentence, proposes id/type/tier/edges as defaults the human confirms or
+overrides, writes a valid node. LLM-assisted drafting is within spirit if
+every field is human-confirmed (proposal ≠ promotion). Default-with-
+override replaces blank-page-with-schema.
+
+### R4. Fail visibly at the moment of authorship
+All current failure is silent and deferred. Invert: validation errors at
+commit time; dangling edges and unknown edge types rejected; `kos
+finding` asks "which brief? [none → marks post_hoc: true]". The tool
+teaches the schema at the point of use.
+
+### R5. One golden path per workflow scale
+`grv-single-workflow-type` established that one ceremony doesn't fit all
+scales. `kos cycle start --scale=probe|feature|fix` sets which steps are
+expected: a bug-scale fix isn't nagged about briefs; a project-scale
+probe is. The expectation profile lives in the state machine, not the
+operator's head.
+
+### R6. Let the graph open the session
+Reopener triggers (v3 Issue 24) plus `kos status` mean graveyard entries,
+fired triggers, and dirty nodes present themselves at session start —
+the lessons-learned retrieval-at-need failure, operationalized in
+reverse. The operator stops being the system's scheduler and becomes its
+judge — the only role the human-as-pawl model ever required.
+
+---
+
+## Part 4 — Onboarding new projects and repos
+
+### Current burden
+The operator must know: that `kos init` exists and where the binary
+lives; which of four topologies applies (in-kos, orc-subrepo, standalone,
+orc-without-kos — the fourth never designed); that init yields an empty
+graph and stub charter; that seeding is their unnamed job; that seed =
+sync-maximally-behind (bedrock insight, prose only — no command
+implements it); and that docs and code are complementary lenses
+(finding-016) requiring both passes.
+
+### R7. `kos adopt <path>` — one verb replacing init + manual seed
+Runs init, inventories the repo (docs, code, git history, CLAUDE.md,
+.claude/, BMAD dirs, ADRs), classifies findings against the two-lens
+model, and *proposes* a seed plan: "47 documents, 3 doc systems detected,
+~15 candidate nodes from docs, ~8 from code structure. Proceed
+lens-by-lens? [docs/code/both/skip]." Every proposed node is
+confirm-or-override — the `kos capture` pattern scaled. This is the
+universal-bridge idea's phase 1, scoped to ingestion only. Human judges;
+tool drives.
+
+### R8. Declared onboarding levels
+Not every repo deserves a full graph. `_kos/kos.yaml` gains
+`level: tracked | seeded | active` — drift-watched only / graph
+populated, no active cycle / full process. Doctor and status scale
+expectations to level. This kills the current binary where a repo is
+either fully ceremonied or invisible — why switchboard/spectacle/curtain
+sit at 17 nodes, zero findings, and no one can say whether that's fine.
+
+---
+
+## Part 5 — Detecting the not-onboarded and the not-working
+
+Today nothing detects either state: a repo without `_kos/` is outside the
+universe; a rotting graph looks identical to a healthy quiet one.
+
+### R9. Workspace census — `kos graphs --census`
+Orc-level walk of all repos; per-repo row: onboarded? level? last graph
+touch? open-loop count? validate status? drift count? One-screen fleet
+view, run by the orc session-start hook. Not-onboarded repos appear as
+*rows, not absences* — the difference between "no data" and
+"known-untracked" is the entire detection game.
+
+### R10. Vital signs, not virtue metrics
+Per-repo health = machine-checkable liveness only (Goodhart rule):
+schema-valid %, dangling edges, fired-but-unaddressed reopeners,
+charter/graph divergence (renderer diff ≠ 0), and the decay signature —
+**days-since-last-graph-touch relative to git activity.** Code moving
+while the graph is frozen = decay; both quiet = dormant, fine. Detectable
+from git alone at zero author cost — the Reflexion pattern applied to
+onboarding itself.
+
+---
+
+## Part 6 — Coexistence with parallel systems
+
+The failure mode to avoid is the one already lived: knowledge duplicated
+into whichever system is guaranteed-loaded, then diverging (F10's
+design-questions.md; charter inflation).
+
+### R11. KOS observes; it never demands migration
+Per the shadow principle, other systems' artifacts are projections KOS
+*reads* — never formats it forces. Beads/convoys, multiclaude worktrees,
+factory pipeline state, BMAD docs keep their native homes. The bridge
+framework's adapter split (fetch is format-specific; understanding is
+LLM-scoped-by-graph) plugs into `kos adopt`'s inventory step. Beads is
+the proven template: `grv-kos-as-task-tracker` drew the boundary (kos =
+knowledge, bd = work) and it holds *because* neither claims the other's
+domain.
+
+### R12. Boundary registry, not integration code
+Small `_kos/coexistence.yaml`: which system owns which artifact class
+(tasks→bd, sessions→multiclaude, pipeline-state→factory,
+specs→BMAD/spectacle) and which are seam-scan *inputs*. Doctor flags
+boundary violations — a task-shaped frontier node, a spec claim living
+only in kos — the same way it flags schema drift. Cheap, declarative,
+makes the division of labor auditable instead of tribal.
+
+### R13. Agent-loop delivery; observation inbox
+Per-agent kos ceremony in multi-agent setups is dead on arrival
+(concurrent soft constraints — the ThreeDoors incident lesson). The MCP
+surface is the coexistence answer: foreign agents *query* the graph
+mid-task and *emit candidate observations* to `_kos/inbox/`, triaged by
+the human at harvest. Agents never write nodes directly; they feed the
+funnel. Proposal ≠ promotion; the pawl is preserved. The inbox also
+answers the multi-topic-source problem: unplaced observations land there
+instead of being lost or misfiled.
+
+### R14. Cross-system drift is just seam detection
+BMAD PRD vs. kos bedrock disagreeing; factory config contradicting an
+architecture node — cross-*system* seams, same signal class as
+cross-document seams. With census scan-inputs declared, every parallel
+system becomes another shadow to triangulate against: coexistence
+*strengthens* the core function rather than competing with it.
+
+---
+
+## Summary table
+
+| # | Recommendation | Burden removed | Cost posture |
+| --- | --- | --- | --- |
+| R1 | `kos status` state machine | 15 memorized duties → 1 habit | machine-paid |
+| R2 | Hooks fire rituals | all cadence memory | machine-paid |
+| R3 | `kos capture` | node-vs-prose cost gap | author-light, confirm-only |
+| R4 | Fail at authorship | schema memorization | machine-paid |
+| R5 | Scale-profiled cycles | ceremony mismatch | machine-paid |
+| R6 | Graph opens session | operator-as-scheduler | machine-paid |
+| R7 | `kos adopt` | init+seed expertise | author-light, confirm-only |
+| R8 | Onboarding levels | all-or-nothing ceremony | declarative |
+| R9 | Fleet census | detection of absence | machine-paid |
+| R10 | Vital signs | detection of decay | machine-paid |
+| R11 | Observe, never migrate | duplication pressure | zero |
+| R12 | Boundary registry | tribal division of labor | declarative |
+| R13 | MCP + inbox | per-agent ceremony | machine-paid |
+| R14 | Cross-system seams | integration code | zero |
+
+Nothing above touches the judgments the SOUL reserves for the human:
+promotion, meaning, dissent. Everything above is the tool assuming the
+scheduling, checking, and proposing that the operator currently performs
+from memory.

--- a/scripts/create-roadmap-issues.sh
+++ b/scripts/create-roadmap-issues.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# create-roadmap-issues.sh — file the roadmap v3/v3.1 issues in ArcavenAE/kos.
+#
+# Source docs: docs/kos-roadmap-v3.md (Issues 1-28; 1-19 reconstructed from
+# v3's "v2 issues stand" summaries) + docs/kos-roadmap-v3_1.md (Issues 29-33,
+# extensions, standing rule 4). Sequencing per the 2026-07-04 two-track
+# adoption consensus (bd aae-orc-b0kp, round-3 amended). Reconciliation map
+# with existing bd tickets: bd aae-orc-4u8m notes.
+#
+# Idempotence: guarded by title search — re-running skips existing titles.
+# bd: aae-orc-dtj0
+
+set -euo pipefail
+
+REPO="ArcavenAE/kos"
+
+# ── Milestones ───────────────────────────────────────────────────────
+declare -a MILESTONES=(
+  "M0 Repair & Truth"
+  "M1 Enforcement Inversion"
+  "MR Retrieval-First"
+  "MO Onboarding & Fleet"
+  "M3 Science"
+  "M4 Substrate"
+  "M5 Mission & Positioning"
+)
+
+echo "== milestones"
+existing_ms=$(gh api "repos/$REPO/milestones?state=all&per_page=100" -q '.[].title')
+for m in "${MILESTONES[@]}"; do
+  if grep -qxF "$m" <<<"$existing_ms"; then
+    echo "exists: $m"
+  else
+    gh api "repos/$REPO/milestones" -X POST -f title="$m" --silent && echo "created: $m"
+  fi
+done
+
+# ── Issue helper ─────────────────────────────────────────────────────
+existing_titles=$(gh issue list -R "$REPO" --state all -L 200 --json title -q '.[].title')
+
+mk() { # mk <milestone> <title> <body>
+  local ms="$1" title="$2" body="$3"
+  if grep -qxF "$title" <<<"$existing_titles"; then
+    echo "skip (exists): $title"
+    return 0
+  fi
+  gh issue create -R "$REPO" --title "$title" --milestone "$ms" --body "$body" | tail -1
+}
+
+FOOT_A="Track A (operator-facing, serial) per bd aae-orc-b0kp."
+FOOT_B="Track B (machine-paid, parallel) per bd aae-orc-b0kp."
+
+echo "== issues"
+
+# ── M0 — Repair & Truth ─────────────────────────────────────────────
+mk "M0 Repair & Truth" "roadmap#1: schema-drift repair + _kos/migrations/ infrastructure (schema v0.4)" \
+"v2-stands per v3 (docs/kos-roadmap-v3.md M0) + v3 addendum: repair observation edges, graveyard type conflation, dangling founding refs; rename maps become \`_kos/migrations/\` with a \`kos migrate\` stub — v0.4 ships WITH its migration path.
+
+Empirical worklist (finding-060, orc): **~128 of 531 fleet edges use undeclared types** (\`related\`=78, \`leaves-open\`=19, \`depends-on\`=9, ...). Decide legalize-vs-retype per type before sweeping.
+
+Coordinate: bd aae-orc-e689 (schema v0.4 provenance/region/conditional_on) — v0.4 ships ONCE with both payloads. bd: aae-orc-fd15 (umbrella). Cost posture: author-neutral, system-paid. $FOOT_B Fed by roadmap#4's failure enumeration."
+
+mk "M0 Repair & Truth" "roadmap#2: charter-content classification" \
+"v2-stands per v3 M0. Classify charter content (graph-derived vs backdrop prose) ahead of cutover. Overlaps bd aae-orc-foqo (T3g charter reduction) + aae-orc-t6pn (T3d dogfood audit) — same work, different framing; coordinate. $FOOT_B"
+
+mk "M0 Repair & Truth" "roadmap#3: charter cutover" \
+"v2-stands per v3 sequencing (n+2 'charter classification, cutover'). Complete the charter-as-renderer cutover for the kos charter (orc F22 pattern; subrepo generalization is bd aae-orc-gezz). $FOOT_B"
+
+mk "M0 Repair & Truth" "roadmap#19: README truth pass" \
+"v2-stands per v3 M0. Bring README claims in line with what the code actually does. Cheap, rides along with M0. $FOOT_B"
+
+# ── M1 — Enforcement Inversion ──────────────────────────────────────
+mk "M1 Enforcement Inversion" "roadmap#4: full-scope validate gate — CLI + CI only (pre-commit severed to roadmap#30)" \
+"v3 M1 + v3.1 R4 extension, AMENDED by the round-3 consensus: ship the full-scope validator + CI job now (machine-paid, author-neutral); the **pre-commit delivery surface is severed** and rides roadmap#30 behind the hook environment contract (bd aae-orc-dxmh, finding-058).
+
+Full-scope means fixing the cwd-scoping bug: validate currently returns the identical 58-node result from every subrepo cwd — fleet coverage ~16% (bd **aae-orc-z67m**, finding-060). Its failure output enumerates the M0 worklist. Add R4 creation-time interrogation: \`kos finding\` prompts 'which brief? [none → post_hoc: true]'; \`kos probe\` prompts for predicted_confidence.
+
+Overlaps: bd aae-orc-1pxb (orc lefthook wiring — the pre-commit half). Dangling targets = error. $FOOT_B — head of Track B."
+
+mk "M1 Enforcement Inversion" "roadmap#18: instrument tests — validate/model/drift/charter (+ status-state fixtures)" \
+"v2-stands per v3 M1 + v3.1 R1-dependency extension: >=20 tests across validate/model/drift/charter; add fixtures for status-machine state derivation (open briefs, unharvested findings, unmoved tiers) consumed by roadmap#29. The validator must be more trustworthy than the graph it judges. $FOOT_B"
+
+mk "M1 Enforcement Inversion" "roadmap#5: context budget accounting (measure-only)" \
+"v3 M1 (modified): ship the accounting; pruning waits for roadmap#20 telemetry to show what's actually read. Cutting before measuring repeats the KM pattern of optimizing unobserved behavior. Related: party finding that machine-paid cost relocates to context budget (bd aae-orc-kx8f notes). $FOOT_B"
+
+mk "M1 Enforcement Inversion" "roadmap#6: artifact-close dashboard signal in kos doctor (not a gate)" \
+"v3 M1 (softened per Goodhart/Austin): sessions closed with/without artifacts becomes a doctor dashboard signal, never a hard gate; two consecutive analysis-only sessions still trigger the graveyard review. Near-identical to bd **aae-orc-0ejy** (doctor warns when substantive commits create no node) — 0ejy is the implementation ticket; keep them linked. $FOOT_B"
+
+# ── MR — Retrieval-First ────────────────────────────────────────────
+mk "MR Retrieval-First" "roadmap#20: retrieval telemetry (per-session append-only files)" \
+"v3 MR (Improvement #7 promoted) + v3.1 R10 extension (per-repo graph-touch timestamps for the decay signature), AMENDED by round-3 consensus: **collection starts immediately** with per-session append-only files keyed by session UUID — the multi-writer question is dissolved, not resolved (see orc frontier node question-kos-multi-writer-concurrency sub-A); the writer-model question gates only the aggregator/consumer.
+
+Pre-registered hypothesis (v3): retrieval follows a power law; >=40% of nodes never read post-creation. One telemetry spine shared with flyloft cue sheets — bd **aae-orc-kx8f**. 10-session clock starts at first collection. Cost posture: author-neutral; produces the benefit ledger. $FOOT_B"
+
+mk "MR Retrieval-First" "roadmap#21: subgraph context format + query commands" \
+"v3 MR (v2 issues 7+8 merged): format spec first, three hand-built ThreeDoors examples, then frontier/bedrock/recent commands emitting it. Retrieval at the moment of need (the LLIS failure inverted).
+
+MUST be designed with the stage-rig epic (bd aae-orc-p4t1, esp. p4t1.8 HippoRAG task-conditional cue study and p4t1.9 paint/refresh/cue commands) — MR and the stage rig describe the same retrieval layer in two vocabularies; do not build two retrieval systems. $FOOT_B"
+
+mk "MR Retrieval-First" "roadmap#22: task-conditional orient" \
+"v3 MR (v2 issue 9): the empirical test of charter-as-cache. Token cost measured against full charter load; either outcome is a finding. Depends on roadmap#21's format. $FOOT_B"
+
+mk "MR Retrieval-First" "roadmap#23: MCP server — read-only epistemic API (+ observation inbox)" \
+"v3 MR (Improvement #8 promoted; 'the delivery mechanism the entire literature says is mandatory') + v3.1 R13 extension (\`_kos/inbox/\` — agents query, agents propose, agents never write nodes; human triages at harvest).
+
+Consensus constraints (bd aae-orc-b0kp + orc frontier question-kos-multi-writer-concurrency): localhost-first Phase 0 (Dolt-server pattern), query/access logging from day one, inbox provenance stamping + per-session rate caps, inbox content never served as graph knowledge, network exposure via switchboard is a parked user decision. Gated on roadmap#21's format AND on M0 repair — an MCP server over a graph that silently drops nodes serves lies with a nice API. $FOOT_B"
+
+mk "MR Retrieval-First" "roadmap#24: reopener triggers — the graveyard's differentiator" \
+"v3 MR, flagged as **the project's most publishable novelty**: graveyard reopeners become machine-checkable structured \`trigger\` conditions (dependency-hash change, date horizon, external-fact assertion) evaluated by \`kos stale\`; fired triggers surface in orient. Negative knowledge that re-presents itself at the moment it becomes relevant — the feature no lessons-learned system ever shipped.
+
+Sequenced AFTER M0 repair (triggers over conflated graveyard nodes fire garbage — round-3 consensus). Design the trigger vocabulary against bd aae-orc-m2bz (T2c bidirectional verb taxonomy). Cost posture: small structured cost at graveyard time (the cheapest moment), machine-delivered benefit forever. Only surviving Toulmin fragment (\`rebuttal_conditions\` on bedrock) doubles as this trigger vocabulary. $FOOT_B"
+
+mk "MR Retrieval-First" "roadmap#29: kos status — the cycle state machine" \
+"v3.1 Issue 29 (R1, R6): reads workspace state and answers 'where am I; what is the next verb' — open loops, obligations, fired reopener triggers (once #24 exists), dirty dependents, stale frontier. Nothing enforced, everything surfaced. Replaces 'read the charter' as the session entry ritual; fifteen memorized duties collapse into one habit.
+
+**Wizard-of-Oz first** (round-2 consensus, Maya): a shell script ships before any Rust; promote only after it survives three real cycles. WoZ prototype + probe brief: aae-orc tools/kos-status + kos/_kos/probes/brief-kos-status-woz.md. AC (v3.1): seeded fixture workspace with three known open loops yields exactly those three obligations. $FOOT_A — head of Track A."
+
+mk "MR Retrieval-First" "roadmap#30: ritual hooks — session-start, post-harvest, Nth-session (gated on hook environment contract)" \
+"v3.1 Issue 30 (R2, R5): session-start → status; post-harvest → charter render; every-Nth-session → graveyard-audit + staleness prompts; pre-commit soft prompts for missing predictor fields; \`kos cycle start --scale=probe|feature|fix\` expectation profiles (fix-scale work is never nagged about briefs).
+
+HARD GATE (round-3 consensus): the hook execution-environment contract must exist first — bd **aae-orc-dxmh** (finding-058: lefthook loses toolchain PATH under agent shells; fail-OPEN semantics; self-diagnostic). This issue also carries roadmap#4's severed pre-commit surface. Overlaps bd aae-orc-b7vi (charter-render CI gate). $FOOT_A"
+
+mk "MR Retrieval-First" "roadmap#31: kos capture — cheap node creation" \
+"v3.1 Issue 31 (R3): one interactive command — sentence in → proposed id/type/tier/edges as confirm-or-override defaults → valid node out. Attacks charter inflation at its source (10-second prose vs 3-minute node). LLM-assisted drafting permitted; every field human-confirmed; proposal != promotion.
+
+AC: capture-to-committed-valid-node under 30s on a fixture; roadmap#20 telemetry later tests whether captured nodes are ever read. Verification-side controls (override-rate vital sign, pawl canaries) tracked in bd **aae-orc-qao2**. Cost posture: author-light, confirm-only. $FOOT_A"
+
+# ── MO — Onboarding & Fleet ─────────────────────────────────────────
+mk "MO Onboarding & Fleet" "roadmap#32: kos adopt + onboarding levels (tracked/seeded/active)" \
+"v3.1 Issue 32 (R7, R8): one verb replacing init+manual-seed — inventory (docs, code, git, CLAUDE.md, .claude/, BMAD, ADRs) → lens-classified seed plan → confirm-or-override node proposals via the capture path. Levels land in \`_kos/kos.yaml\`; doctor and status scale expectations to level.
+
+Baseline motivation measured (finding-060): 7 fleet graphs have nodes but zero findings/briefs and nobody can say whether that's fine. AC: adopt on one real BMAD-born repo yields a reviewed seed of >=10 nodes with zero hand-written YAML; finding-016's both-lenses requirement enforced. LAST on Track A — do not onboard the fleet onto an unproven loop. $FOOT_A"
+
+mk "MO Onboarding & Fleet" "roadmap#33: fleet census + vital signs + coexistence registry" \
+"v3.1 Issue 33 (R9, R10, R12, R14): \`kos graphs --census\` per-repo rows (onboarded?, level, last graph touch, open loops, validate status, drift count, decay signature — graph-frozen-while-git-moves). Not-onboarded repos are rows, not absences. Vital signs are liveness only — **diagnostic, never gates; no kos vital sign in branch protection or required checks** (Goodhart enforcement location, round-1 Priya).
+
+Deployment pattern (consensus): compute via launchd LaunchAgent to a cached status file; session-start reads the file, never walks 20 repos. \`_kos/coexistence.yaml\` declares system boundaries (tasks→bd, sessions→multiclaude, pipeline-state→factory, specs→BMAD/spectacle); doctor flags boundary violations; cross-system contradictions enter seam detection (R14). R11 (observe, never migrate) recorded as a design value node, not an issue. Sub-check overlap: bd aae-orc-hoi2. Baseline instrument to absorb: aae-orc scripts/kos-baseline-vitals.sh (finding-060). $FOOT_B"
+
+# ── M3 — Science ────────────────────────────────────────────────────
+mk "M3 Science" "roadmap#25: retrodiction engine — kos asof + blinded historical seam replay" \
+"v3 M3, first science item ('the project's highest-credibility experiment and its best paper'): \`kos asof <ref>\` reconstructs the graph at a historical commit; replay seam detection on the four ThreeDoors incidents; operator blinded to incident selection; prediction registered before running (>=2 of 4 detectable at T-minus-one-sprint). Backtesting hygiene per Bailey et al.; the blinding protocol is not optional, it IS the experiment (Fischhoff/Dekker). Blinding design must account for one-operator-shared-agent-context reality (party round 1, Mary). Rides the MCP read surface (round-2 consensus). $FOOT_B"
+
+mk "M3 Science" "roadmap#10: calibration pipeline — Brier scoring on predicted_confidence" \
+"v2-stands per v3 M3, survey-hardened: adopt Brier scoring + forecasting apparatus wholesale; surprise_magnitude maps to calibration residuals; briefs ARE registered reports (no post-hoc hypothesis editing; post_hoc:true flag; HARKing named). Lock predictions — timestamped, immutable post-harvest. Baseline (finding-060): predicted_confidence in 1/19 kos briefs, 8/19 orc. Upstream design input: bd aae-orc-szh (predictor engine layer). $FOOT_B"
+
+mk "M3 Science" "roadmap#11: controlled baseline — naive LLM-over-docs vs graph" \
+"v2-stands per v3 M3: finding-023 rubric, two projects. Does the graph beat a naive LLM reading the documents cold? $FOOT_B"
+
+mk "M3 Science" "roadmap#17: typed-edge thesis test — the formality tax, measured" \
+"v2-stands per v3 M3, sharpened: retype 50 edges, measure traversal value AND authoring cost per typed edge. If value < cost, prune the taxonomy to derives/contradicts/supersedes and treat as confirmation of incremental-formalization literature, not defeat.
+
+Baseline data ready (finding-060): fleet derives share 52.5% (69% of valid-typed edges); 24% of edges use undeclared types — the taxonomy already failed its authors once (Bowker/Star residual-category reading, party round 1 Maya: grow edge types bottom-up from prose vocabulary). Transcript-mining input: bd aae-orc-b6tu. $FOOT_B"
+
+mk "M3 Science" "roadmap#26: canary nodes — epistemic chaos engineering (dead last)" \
+"v3 M3: three canaries across tiers, sealed hash-committed registration, five normal sessions, reveal. The only game-resistant health metric (L5).
+
+Sequenced DEAD LAST on both tracks (unanimous, rounds 1-3). Gates before any planting (bd **aae-orc-j53y**): failure-class taxonomy from the graveyard corpus; canaries declared in a signed OUT-OF-BAND registry (append-only history means a canary is reachable at every historical ref forever — kos asof and MCP must be canary-aware by default); written control narrative (auditor-facing). $FOOT_B"
+
+mk "M3 Science" "roadmap#12: inter-rater reliability — Cohen's kappa on a 30-finding sample" \
+"v2-stands per v3 M3. Do two raters classify the same findings the same way? $FOOT_B"
+
+mk "M3 Science" "roadmap#13: external-operator probe" \
+"v2-stands per v3 M3, cheapened by roadmap#32 (adopt) + roadmap#23 (MCP): the probe cost drops from 'coach a stranger through expert ceremony' to 'hand them two commands' — which is itself the measurement. Also the first real test of the Grudin thesis outside the solo-operator mask (party round 1, Victor: onboarding isn't a feature, it's the experiment that validates the entire thesis). $FOOT_B"
+
+mk "M3 Science" "roadmap#14: scheduled graveyard audit — every 3 sessions, 10-session sunset rule" \
+"v2-stands per v3 M3; hook-prompted once roadmap#30 lands. $FOOT_B"
+
+# ── M4 — Substrate ──────────────────────────────────────────────────
+mk "M4 Substrate" "roadmap#15: substrate probes (gated on M0-MR)" \
+"v2-stands per v3 M4 + survey addition: every substrate probe brief must answer the three MDE killers (tool lock-in, round-trip breakage, skill asymmetry) before it runs. Related evidence: orc question-kos-multi-writer-concurrency sub-C (node-write concurrency threshold — at what creation rate does YAML-in-git need the bd Phase 0 treatment). $FOOT_B"
+
+# ── M5 — Mission & Positioning ──────────────────────────────────────
+mk "M5 Mission & Positioning" "roadmap#16: mission split + graveyard continuity-via-infrastructure" \
+"v2-stands per v3 M5. $FOOT_B"
+
+mk "M5 Mission & Positioning" "roadmap#27: chronicle — narrative projection of causal history" \
+"v3 (Improvement #9, admitted as read-side projection): \`kos chronicle <node>\` walks provenance/edge chains chronologically, emits a structured event list; optional LLM prose pass with citation-per-sentence discipline (if citation coverage can't reach ~100%, ship the event list and skip the prose). Reuses roadmap#21's traversal — dependency, not deferral. Paired with roadmap#13 as its comprehension benchmark. Party note (Maya): session logs are already a voluntarily-paid chronicle — build on the thriving capture behavior. $FOOT_B"
+
+mk "M5 Mission & Positioning" "roadmap#28: publishable claims register" \
+"v3 M5: three paper-shaped claims tracked to evidentiary closure — (a) retrodictive seam detection (roadmap#25), (b) reopener-triggered negative knowledge (roadmap#24), (c) calibrated engineering hypotheses (roadmap#10 at n>=30). Nothing drafted until its evidence closes. Party note (Victor): the wedge is the retrodiction result; straddling five research communities is positioning in none. $FOOT_B"
+
+echo "== done"


### PR DESCRIPTION
## What

Five documents from the 2026-07-04 research session, checked in as-received (one filename normalized).

| Doc | Authored | Role |
|---|---|---|
| `kos-nine-improvements.md` | 13:26 | Nine proposals beyond the current vision, each at probe depth. Retained as the pre-registration record — its predictions predate the literature survey. |
| `kos-prior-work-survey.md` | 14:04 | Breadth-first literature survey: 17 kos concepts mapped to five decades of prior work, failure-mode emphasis. Full BibTeX included. Renamed from "Mapping KOS to Prior Work_ ...". |
| `kos-nine-improvements-reassessed.md` | 14:29 | The nine re-read through the survey: 2 strengthened (#5 retrodiction, #8 MCP), 3 modified (#2 canaries, #3 half-life, #7 economics), 3 correctly deferred (#1, #6, #9), 1 partially killed (#4 Toulmin fields). **Supersedes the standalone verdicts in the original nine doc.** |
| `kos-use-assessment.md` | 14:49 | Operator-burden analysis: fifteen expert judgments per cycle, skipping is the norm; fourteen recommendations R1–R14 ("the tool drives the process; the operator makes the decisions"). |
| `kos-roadmap-v3_1.md` | 14:49 | Delta roadmap folding R1–R14 into the v3 milestone structure: Issues 29–33, new MO sub-milestone, standing rule 4 (Bainbridge). |

## Reading order

survey → reassessed → use assessment → roadmap v3.1. The original nine-improvements doc is historical context.

## Known gap

`kos-roadmap-v3.md` — the base document v3.1 deltas against (Issues 1–28, roadmap BibTeX, and reportedly the gh-issue creation script) — was **not** in this drop. Tracked separately; do not treat v3.1 as self-contained.

## Not in this PR

- No graph/nodes changes — harvest of these docs into `_kos/` (findings, frontier questions, graveyard-informing entries) is follow-on work, tracked in bd.
- No GitHub issues created yet — blocked on recovering the v3 base doc.