### PR TITLE
fix(validate): cwd-scoped graph resolution + accumulating --merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ graphs, detects drift, and surfaces relevant knowledge per-repo:
 
 ```
 kos orient <repo>     # what does the graph know about this repo?
-kos validate          # schema check all nodes
+kos validate          # schema check the nearest graph (--merged for all)
 kos graph             # render node graph (mermaid or dot)
 kos drift             # content hash + edge walk → flag stale dependents
 kos bridge            # extract findings from prose briefs

--- a/docs/product-brief.md
+++ b/docs/product-brief.md
@@ -41,9 +41,12 @@ Probe: brief-kos-orient. Session-006.
 
 ### `kos validate`
 
-Validate all nodes against the schema. Checks: required fields, confidence
-values, edge targets exist, filename matches node ID, file in correct
-confidence directory. Reports pass/fail per node.
+Validate nodes against the schema. Scopes to the graph nearest the
+current directory (the local subrepo graph when inside one, the
+orchestrator graph at the orc root); `--merged` validates every
+discovered graph and reports a combined summary. Checks: required
+fields, confidence values, edge targets exist, filename matches node
+ID, file in correct confidence directory. Reports pass/fail per node.
 
 First mechanical test of schema v0.3 (revised three times, never tooled).
 Probe: brief-schema-tooling. Session-007.

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,10 +40,14 @@ enum Commands {
         ready: bool,
     },
 
-    /// Validate all nodes against the schema
+    /// Validate nodes against the schema (nearest graph by default)
+    ///
+    /// Validates the graph nearest to the current directory: the local
+    /// subrepo graph when run inside one, the orchestrator graph at the
+    /// orc root. Use --merged to validate every discovered graph.
     Validate {
-        /// Validate all discovered graphs (orchestrator + includes)
-        #[arg(long)]
+        /// Validate all discovered graphs (orchestrator + includes + subrepos)
+        #[arg(long, alias = "all")]
         merged: bool,
     },
 
@@ -267,26 +271,50 @@ fn main() -> anyhow::Result<()> {
             let workspace = kos::workspace::Workspace::discover(&cwd)?;
 
             if merged {
-                // Validate all discovered graphs
-                let mut total_errors = 0;
+                // Validate every discovered graph, accumulating results —
+                // one failing graph must not mask the others (aae-orc-z67m).
+                let mut combined = kos::validate::Summary::default();
+                let mut io_errors = 0;
                 for graph in &workspace.graphs {
                     eprintln!("Validating graph: {} ({})", graph.graph_id, graph.scope);
-                    if let Err(e) = kos::validate::run(&graph.path) {
-                        eprintln!("  error: {e}");
-                        total_errors += 1;
+                    match kos::validate::run(&graph.path) {
+                        Ok(summary) => combined.merge(&summary),
+                        Err(e) => {
+                            eprintln!("  error: {e}");
+                            io_errors += 1;
+                        }
                     }
                 }
                 // Also validate legacy layout if no _kos/ graphs found
                 if workspace.graphs.is_empty() {
-                    kos::validate::run(&workspace.kos_root)?;
+                    combined.merge(&kos::validate::run(&workspace.kos_root)?);
                 }
-                if total_errors > 0 {
+                eprintln!();
+                eprintln!(
+                    "all graphs: {} nodes, {} passed, {} warnings, {} failed, {} parse errors",
+                    combined.total,
+                    combined.passed,
+                    combined.warnings,
+                    combined.failed,
+                    combined.parse_errors
+                );
+                if !combined.clean() || io_errors > 0 {
                     std::process::exit(1);
                 }
             } else {
-                // Validate nearest graph or legacy layout
-                let node_root = workspace.node_root();
-                kos::validate::run(&node_root)?;
+                // Validate the graph nearest to cwd — the local subrepo graph
+                // when inside one, the orchestrator graph at orc root.
+                // Previously this always resolved to the kos repo's own graph
+                // regardless of cwd (aae-orc-z67m / finding-060 anomaly 1).
+                let summary = if let Some(graph) = workspace.nearest_graph(&cwd) {
+                    eprintln!("Validating graph: {} ({})", graph.graph_id, graph.scope);
+                    kos::validate::run(&graph.path)?
+                } else {
+                    kos::validate::run(&workspace.node_root())?
+                };
+                if !summary.clean() {
+                    std::process::exit(1);
+                }
             }
         }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -18,12 +18,38 @@ impl ValidationResult {
     }
 }
 
+/// Aggregate outcome of validating one graph. The caller decides the
+/// process exit code — `run` never exits, so multi-graph validation
+/// can accumulate results across graphs (kos#54 / aae-orc-z67m).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Summary {
+    pub total: usize,
+    pub passed: usize,
+    pub warnings: usize,
+    pub failed: usize,
+    pub parse_errors: usize,
+}
+
+impl Summary {
+    pub fn clean(&self) -> bool {
+        self.failed == 0 && self.parse_errors == 0
+    }
+
+    pub fn merge(&mut self, other: &Summary) {
+        self.total += other.total;
+        self.passed += other.passed;
+        self.warnings += other.warnings;
+        self.failed += other.failed;
+        self.parse_errors += other.parse_errors;
+    }
+}
+
 /// Run the validate subcommand against all nodes in the kos root.
-pub fn run(kos_root: &Path) -> Result<()> {
+pub fn run(kos_root: &Path) -> Result<Summary> {
     let nodes_dir = kos_root.join("nodes");
     if !nodes_dir.exists() {
         println!("no nodes/ directory found at {}", kos_root.display());
-        return Ok(());
+        return Ok(Summary::default());
     }
 
     // First pass: load all nodes and collect IDs
@@ -77,11 +103,13 @@ pub fn run(kos_root: &Path) -> Result<()> {
         "{total} nodes: {pass_count} passed, {warn_count} warnings, {fail_count} failed, {parse_error_count} parse errors",
     );
 
-    if fail_count > 0 || parse_error_count > 0 {
-        std::process::exit(1);
-    }
-
-    Ok(())
+    Ok(Summary {
+        total,
+        passed: pass_count,
+        warnings: warn_count,
+        failed: fail_count,
+        parse_errors: parse_error_count,
+    })
 }
 
 /// A loaded node: either successfully parsed or failed to parse.

--- a/tests/validate_scoping.rs
+++ b/tests/validate_scoping.rs
@@ -1,0 +1,121 @@
+//! Integration tests for validate graph scoping (aae-orc-z67m / kos#54).
+//!
+//! Regression under test: `kos validate` previously resolved to the kos
+//! repo's own graph from every cwd, so subrepo graphs were never
+//! validated and fleet "0 failed" was coverage illusion (finding-060).
+
+use std::fs;
+use std::path::Path;
+
+use kos::validate;
+use kos::workspace::Workspace;
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn node_yaml(id: &str, confidence: &str) -> String {
+    format!("id: {id}\ntype: element\nconfidence: {confidence}\ntitle: \"t\"\ncontent: \"c\"\n")
+}
+
+/// Build a fixture workspace: standalone-style root graph plus one
+/// subrepo graph, with different node counts so scoping is observable.
+fn fixture(root: &Path) {
+    // Orchestrator-shaped root: _kos with 1 valid node
+    write(
+        &root.join("_kos/kos.yaml"),
+        "graph_id: fixture-orc\nscope: orchestrator\nschema_version: '0.3'\nincludes:\n- path: sub/_kos\n",
+    );
+    write(
+        &root.join("_kos/nodes/bedrock/elem-one.yaml"),
+        &node_yaml("elem-one", "bedrock"),
+    );
+
+    // Subrepo graph: 2 valid nodes + 1 misfiled node (frontier file in bedrock/)
+    write(
+        &root.join("sub/_kos/kos.yaml"),
+        "graph_id: fixture-sub\nscope: repo\nschema_version: '0.3'\n",
+    );
+    write(
+        &root.join("sub/_kos/nodes/frontier/question-a.yaml"),
+        &node_yaml("question-a", "frontier"),
+    );
+    write(
+        &root.join("sub/_kos/nodes/frontier/question-b.yaml"),
+        &node_yaml("question-b", "frontier"),
+    );
+    write(
+        &root.join("sub/_kos/nodes/bedrock/elem-misfiled.yaml"),
+        &node_yaml("elem-misfiled", "frontier"),
+    );
+}
+
+#[test]
+fn nearest_graph_resolves_subrepo_graph_from_subrepo_cwd() {
+    let tmp = tempfile::tempdir().unwrap();
+    fixture(tmp.path());
+
+    let ws = Workspace::from_explicit(tmp.path()).unwrap();
+    assert_eq!(ws.graphs.len(), 2, "orc graph + included subrepo graph");
+
+    let nearest = ws.nearest_graph(&tmp.path().join("sub")).unwrap();
+    assert_eq!(nearest.graph_id, "fixture-sub");
+
+    let at_root = ws.nearest_graph(tmp.path()).unwrap();
+    assert_eq!(at_root.graph_id, "fixture-orc");
+}
+
+#[test]
+fn validate_summaries_differ_per_graph() {
+    let tmp = tempfile::tempdir().unwrap();
+    fixture(tmp.path());
+
+    let ws = Workspace::from_explicit(tmp.path()).unwrap();
+
+    let orc = ws
+        .graphs
+        .iter()
+        .find(|g| g.graph_id == "fixture-orc")
+        .unwrap();
+    let sub = ws
+        .graphs
+        .iter()
+        .find(|g| g.graph_id == "fixture-sub")
+        .unwrap();
+
+    let orc_summary = validate::run(&orc.path).unwrap();
+    assert_eq!(orc_summary.total, 1);
+    assert_eq!(orc_summary.failed, 0);
+    assert!(orc_summary.clean());
+
+    let sub_summary = validate::run(&sub.path).unwrap();
+    assert_eq!(sub_summary.total, 3);
+    assert_eq!(
+        sub_summary.failed, 1,
+        "misfiled node (frontier confidence in bedrock/) must fail"
+    );
+    assert!(!sub_summary.clean());
+
+    // The regression: identical summaries from every scope meant the
+    // subrepo graph was never read. These must differ.
+    assert_ne!(orc_summary.total, sub_summary.total);
+}
+
+#[test]
+fn summary_merge_accumulates_across_graphs() {
+    let tmp = tempfile::tempdir().unwrap();
+    fixture(tmp.path());
+
+    let ws = Workspace::from_explicit(tmp.path()).unwrap();
+    let mut combined = validate::Summary::default();
+    for g in &ws.graphs {
+        combined.merge(&validate::run(&g.path).unwrap());
+    }
+    assert_eq!(combined.total, 4);
+    assert_eq!(combined.failed, 1);
+    assert!(
+        !combined.clean(),
+        "one failing graph must fail the merged run"
+    );
+}


### PR DESCRIPTION
Fixes the validate scoping bug (bd `aae-orc-z67m`, finding-060 anomaly 1; part of roadmap#4 → #54).

## Before
`kos validate` returned the identical `58 nodes: 54 passed ... 0 failed` from **every** cwd — it always resolved the kos repo's own graph. 361+ node files across 14 fleet graphs; validation covered 58 (~16%). ~128 undeclared-type edges accumulated under green checks. `--merged` also aborted at the first failing graph because `validate::run` called `process::exit` internally.

## After
- Default run validates the graph **nearest to cwd** (local subrepo graph inside one, orchestrator graph at orc root), and says which graph it's validating.
- `validate::run` returns a `Summary`; `--merged` (new alias `--all`) accumulates across all discovered graphs and prints a combined line; exit code decided once.
- README / product-brief / clap help updated to match behavior.

## Measured on the live fleet
```
all graphs: 382 nodes, 222 passed, 58 warnings, 0 failed, 102 parse errors → exit 1
```
Newly visible: marvel 14/25 unparseable, sideshow 15/23, switchboard 11/13, orc 4/76. This enumeration is the M0 repair worklist (#51).

## Tests
`tests/validate_scoping.rs` — nearest-graph resolution from subrepo cwd, per-graph summary divergence (the regression), cross-graph accumulation. `just ci` green.

Refs #54, #51. bd: aae-orc-z67m.