### PR TITLE
docs: source original roadmap v1 + v2 (primary-source edition)

### DIFF
--- a/docs/kos-roadmap-v2.md
+++ b/docs/kos-roadmap-v2.md
@@ -1,0 +1,323 @@
+# KOS Assessment & Roadmap v2 — Primary-Source Edition
+
+> Supersedes `kos-roadmap.md` (v1). v1 was built from README, a truncated
+> charter fetch, and secondhand reports. v2 is built from full inspection of
+> the uploaded repo (`kos-main.zip`): all 260 graph artifacts, schema, Rust
+> source, CI, hooks. Every claim below carries a path. Nodes were weighted
+> over prose per instruction; both were tested against the code.
+
+---
+
+## Part 1 — What inspection verified (claims that held)
+
+**V1. The signal-yield claim is better grounded than v1 credited.**
+`_kos/findings/finding-023-signal-to-noise-four-projects.yaml` documents real
+methodology: owner ground-truth classification on ThreeDoors (40%
+consequential / 30% low / 30% noise) and independent-discovery
+cross-referencing on OpenClaw (graph findings matched community-discovered
+issues #23314 and #4940 — convergent validation), Atmos, and GitLab. This is
+not hand-waving. What's still missing is a *control*: no naive
+LLM-over-documents baseline has ever been run, so KOS's marginal value over
+the obvious alternative remains unmeasured. (v1 Issue 11 stands, premise
+corrected.)
+
+**V2. The graveyard is real and mostly disciplined.** 9 entries in
+`_kos/nodes/graveyard/`, five with full approach/ruling/reopener structure.
+`grv-kos-as-task-tracker` shows genuine scope self-pruning.
+
+**V3. The CLI is substantial, not vaporware.** 16 modules in `src/`:
+orient, validate, graph, drift, bridge, seed, compact, reflect, doctor, init,
+charter (with `--write`), plus node-creation helpers (idea/question/finding/
+probe). The charter renderer reported in-conversation exists at
+`src/charter.rs` with the regeneration warning banner already written.
+
+**V4. Process linkage exists.** The charter tracks completed frontier items
+with strikethrough + finding references (F-items → finding-029/030/031/032).
+The session-002 harvest checklist survived into `CLAUDE.md:81-109`. Commit
+vocabulary (harvest/promote/graveyard/probe) is documented.
+
+**V5. Findings are evidence-shaped.** Sampled findings contain success-signal
+scoring against briefs, honest PARTIAL results, and misses enumerated
+alongside hits (finding-016 lists 9 of 11 missed issues explicitly).
+
+---
+
+## Part 2 — What inspection falsified or downgraded
+
+**F1. The knowledge graph has ZERO automated validation. Anywhere.**
+- `.github/workflows/ci.yml:12,21` — CI **paths-ignores `_kos/**`** entirely.
+- `lefthook.yml` — pre-commit runs cargo fmt/clippy/deny; pre-push runs
+  cargo test. No hook touches nodes.
+- `kos validate` exists (`src/validate.rs`) but nothing invokes it
+  automatically.
+
+The project's own bedrock finding — *"instruction-based enforcement fails;
+infrastructure enforcement works"* (`elem-gate-enforcement`, README §"What
+we've learned" item 4) — is **inverted in its own repo: the code is gated,
+the knowledge is not.** This is the single sharpest result of the deep dive.
+
+**F2. Validation has a scope hole, and the hole contains live schema drift.**
+`src/validate.rs:23` loads only `nodes/**`. Probe-produced node sets in
+`_kos/probes/brief-*-nodes/` (15 files across 3 probe dirs) are never parsed.
+Those files contain **15 edges of type `observation`** — a type absent from
+both `schema/node.schema.yaml` and the Rust `EdgeType` enum
+(`src/model.rs:131-165`). Serde would hard-reject them if ever loaded. The
+exact silent-drift class the renderer just exposed in the orc repo (11 nodes)
+exists in kos itself, undetected. The instrument does not point at itself.
+
+**F3. Edge-type monoculture: the typed-edges thesis is ~92% unexercised.**
+Across all artifacts: `derives` ×414, `supersedes` ×10, `contradicts` ×10,
+`observation` ×5 in nodes-adjacent files (undefined), `implements` ×4,
+`partially_resolves` ×2, and **zero** uses of `supports`, `instantiates`,
+`discovered_from`. The founding thesis — typed relationships make corruption
+audible — rests on a graph where 92% of relationships use the weakest,
+most generic type. Either the taxonomy is wrong-sized or the discipline
+never formed. This is testable (see Issue 17).
+
+**F4. Referential integrity is soft and already broken.** Edge targets
+reference IDs that don't exist: `val-uncertainty-first` (renamed to
+`val-uncertainty-structural`), `elem-collaboration-model`, `finding-016`,
+`td-phase1-validated`, `ax-arch-validation`, `ax-claude-md` — ~6 real
+dangling targets. `validate.rs:158-162` emits only a *warning* ("may be a
+finding or probe") because `known_ids` is built solely from `nodes/`, so it
+cannot distinguish a legitimate cross-directory reference from a broken one.
+Founding-node provenance chains are severed and nothing fails.
+
+**F5. Type/confidence conflation regressed inside the graveyard.** 4 of 9
+graveyard files carry `type: element` with `confidence: graveyard` and lack
+approach/reopener fields (`grv-flat-file-context-scaling`,
+`grv-human-as-integration-bus`, `grv-reactive-query-model`,
+`grv-single-workflow-type`). Two node models coexist; the schema's own
+graveyard structure is honored ~55%.
+
+**F6. The predictor layer is near-empty in this repo.** Exactly **1** brief
+carries `predicted_confidence` (0.6) and **3** findings carry
+`surprise_magnitude` (low, medium, medium). The platform-Claude's report of
+"5+ briefs / 4+ findings" is not substantiated here (possibly distributed in
+repos not provided — unverifiable). Additionally **8 of 43 findings (19%)
+have `probe: null`** — post-hoc findings with no pre-registered hypothesis.
+Pre-registration is aspirational, not practiced.
+
+**F7. The epistemically load-bearing code is untested.** 12 unit tests total,
+confined to `process.rs` and `updater.rs`. Zero tests for `validate.rs`,
+`model.rs` (parsing/enum enforcement), `drift.rs`, or `charter.rs`. The
+self-updater is better tested than the knowledge validator.
+
+**F8. Documentation drift in the flagship's own front matter.**
+README claims a `placeholder/` node directory (`README.md:239`) — absent.
+`sessions/` contains only `session-001.md` despite ~20 sessions of history;
+the session log lives inline in the charter (the pattern the orc analysis
+condemned). Charter is 889 lines and growing.
+
+**F9. Frontier staleness with no sunset mechanism.** 25 of 26 frontier nodes
+were created ≥3 months ago (8 from the founding date 2026-03-15); 1 created
+this month. No audit cadence exists in the protocol.
+
+---
+
+## Part 3 — Process-in-use, critically
+
+The cycle (orient → ideate → question → probe → harvest → promote) is
+genuinely practiced — briefs exist, findings score against success signals,
+completions link back. Three structural critiques survive contact with the
+evidence:
+
+1. **All enforcement is voluntary.** Every discipline mechanism (checklist,
+   validate, commit vocabulary) is instruction, not infrastructure. F1/F2
+   are the direct consequence. The project *discovered* this principle
+   empirically (ThreeDoors incident convergence) and has not applied it
+   to itself.
+
+2. **Probe granularity is elastic post-hoc.** `brief-mvg-bootstrap` is
+   credited as the probe for 13 findings — the entire 12-project sweep was
+   retrofitted under one umbrella brief. Combined with 19% probe-null
+   findings, "probes are timeboxed with declared success signals" describes
+   the ideal, not the median practice.
+
+3. **The graph's connective tissue is thinner than its node count.** 260
+   artifacts connected almost entirely by `derives` means traversal answers
+   "what came from what" but rarely "what conflicts with what" or "what
+   replaced what" — the queries that justified typed edges in the first
+   place. The 10 `contradicts` edges are where nearly all the demonstrated
+   signal value lives (ThreeDoors incident convergence). That ratio is the
+   thesis's own signal-to-noise problem.
+
+**Net:** The concept survives inspection. The practice is a partially
+disciplined prototype whose central claims are (a) genuinely evidenced at
+the signal-detection layer, (b) unenforced at the integrity layer, and
+(c) untested at the typed-edge and prediction layers.
+
+---
+
+## Part 4 — Roadmap v2 (diff against v1)
+
+**Unchanged:** Issues 2, 3, 5, 6, 7, 8, 9, 13, 14, 15, 16 stand as written
+in v1. **Revised:** 1, 4, 10, 11 below. **New:** 17, 18, 19.
+
+---
+
+### Issue 1 (REVISED): Repair schema drift in BOTH repos' graphs
+**Labels:** `bug`, `schema`, `M0`
+
+Scope expands. In kos itself: 15 `observation` edges in
+`_kos/probes/brief-*-nodes/`; 4 graveyard nodes with `type: element` and
+missing approach/reopener fields; ~6 dangling edge targets including renamed
+founding nodes (`val-uncertainty-first`→`val-uncertainty-structural`). Plus
+the 11 orc-repo nodes from the renderer report.
+
+**AC:** `kos validate` (post-Issue-4 scope) passes clean on both graphs;
+each repair class recorded in one finding; rename map committed so
+provenance chains resolve.
+
+---
+
+### Issue 4 (REVISED): Close the enforcement inversion
+**Labels:** `infrastructure`, `schema`, `M1` — **promoted to highest
+priority in M1; cheapest highest-leverage fix in the entire roadmap**
+
+Three concrete changes:
+(a) `validate.rs` scope: load `nodes/**`, `findings/**`, `probes/**`
+(including `brief-*-nodes/` subdirs); build `known_ids` from all of them;
+dangling target = **error**, not warning (allow explicit `external:` prefix
+for cross-repo refs).
+(b) Remove `_kos/**` from CI `paths-ignore`; add a CI job running
+`kos validate --merged`.
+(c) Add `kos validate` to `lefthook.yml` pre-commit.
+
+**AC:** A node with an undefined edge type, or a dangling target, cannot be
+committed or merged. The `observation` files fail until Issue 1 fixes them —
+that failure firing is the acceptance test.
+
+---
+
+### Issue 10 (REVISED): Calibration pipeline — corrected premise
+**Labels:** `science`, `predictor`, `M3`
+
+v1 assumed calibration data was "in flight." Ground truth: n=1 brief,
+n=3 findings in this repo. There is no backfill — pre-registration cannot
+be retrofitted honestly.
+
+**Deliverables:** `predicted_confidence` required (schema + validate) on all
+*new* briefs; `surprise_magnitude` required on all *new* findings;
+`probe: null` findings permitted only with an explicit `post_hoc: true` flag
+and rationale. `kos calibration` report ships when n≥10 pairs exist.
+**AC:** First report at n≥10; probe-null rate tracked as a process metric
+(current baseline: 19%).
+
+---
+
+### Issue 11 (REVISED): Controlled baseline — cite what exists
+**Labels:** `science`, `validation`, `M3`
+
+finding-023's convergent-discovery method (community issues independently
+confirming graph findings) is real external validation and should be
+foregrounded in README. The remaining gap is the counterfactual: same
+documents, same time budget, capable LLM, **no graph** — does it find the
+same seams?
+
+**AC:** Baseline run on ThreeDoors + one other previously-probed project
+using the finding-023 rubric; overlap/precision/unique-yield reported;
+README's yield claims cite both finding-023 and the controlled result.
+
+---
+
+### Issue 17 (NEW): Test the typed-edge thesis or right-size the taxonomy
+**Labels:** `science`, `schema`, `M3`
+
+92% `derives`, three types never used. Two-part probe:
+(a) Retype a 50-edge sample where a more specific type applies; measure what
+`contradicts`/`supersedes`/`implements` traversal answers that `derives`
+cannot (use the ThreeDoors incident-convergence query as the benchmark —
+it is the project's best demonstrated typed-edge win).
+(b) Sunset decision on `supports`/`instantiates`/`discovered_from`: earn
+first use within the probe or move to a schema graveyard note.
+
+**AC:** Finding quantifies typed-edge marginal value; schema v0.4 either
+defends or prunes the unused types. This is a direct empirical test of a
+founding bedrock claim (`val-typed-traversable`) — treat a negative result
+as bedrock-challenging.
+
+---
+
+### Issue 18 (NEW): Test the instrument
+**Labels:** `code-quality`, `M1`
+
+Zero tests on validate/model/drift/charter. Minimum set: EdgeType enum
+rejection of unknown types; dangling-target detection (post-Issue-4
+semantics); graveyard-node structural requirements; charter render
+idempotence (render → render produces identical output); drift hash
+stability.
+
+**AC:** ≥20 tests across those four modules; CI green; a deliberately
+malformed fixture node fails the suite.
+
+---
+
+### Issue 19 (NEW): Truth pass on self-description
+**Labels:** `docs`, `M0`
+
+README claims `placeholder/` (absent); `sessions/` implies history it
+doesn't hold; charter embeds the session log the project's own analysis
+condemned.
+
+**AC:** README structure matches `ls`; session log extracted to
+`sessions/` or `_kos/session-log.md` with charter pointer (this also
+pre-implements part of Issue 2); every quantitative README claim cites a
+finding ID.
+
+---
+
+### Revised sequencing
+
+```
+Session n:    Issue 4 (enforcement)  ← firing failures become the worklist
+Session n+1:  Issues 1, 19           (repairs + truth pass, guided by the gate)
+Session n+2:  Issues 2, 3            (charter classification + cutover)
+Session n+3:  Issues 18, 5           (instrument tests, context budget)
+Session n+4:  Issues 6, 7            (artifact rule, subgraph format)
+Session n+5:  Issues 8, 9, 14        (queries, task-orient, first graveyard audit)
+Then:         10, 11, 17 (science block) · 12, 13 · 15 gated on M0–M2 · 16 anytime
+```
+
+Ordering change from v1: **enforcement before repair.** Turning the gate on
+first makes the drift enumerate itself — the failures are the repair
+checklist, and the gate proves itself by catching them.
+
+---
+
+## Part 5 — Import script (delta)
+
+Prereq: v1 issues 2,3,5–9,13–16 created from the v1 script. This creates the
+revised/new set. Commit this file as `docs/roadmap-v2-2026-07.md` first.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+R="ArcavenAE/kos"; D="docs/roadmap-v2-2026-07.md"
+i(){ gh issue create --repo $R --title "$1" --label "$2" --body "$3
+
+Evidence & full spec: $D (Issue $4)"; }
+
+i "Repair schema drift in kos + orc graphs (observation edges, graveyard type conflation, dangling founding refs)" "bug,schema,M0" \
+"kos repo: 15 undefined 'observation' edges in _kos/probes/brief-*-nodes/; 4 graveyard nodes typed 'element' missing approach/reopener; ~6 dangling targets incl. val-uncertainty-first rename. Plus 11 orc nodes. AC: validate clean on both; rename map committed." 1
+i "Close the enforcement inversion: validate scope + CI + pre-commit" "infrastructure,schema,M1" \
+"CI paths-ignores _kos/**; lefthook runs cargo only; validate.rs loads nodes/ only and only WARNS on dangling targets. Fix all three: full-scope validation, dangling=error (external: prefix escape), CI job, pre-commit hook. AC: the existing observation-edge files fail the gate — that firing is the acceptance test." 4
+i "Calibration pipeline (corrected premise: n=1 brief, n=3 findings today)" "science,predictor,M3" \
+"No backfill possible. Require predicted_confidence on new briefs, surprise_magnitude on new findings, post_hoc:true flag for probe-null findings (current rate 19%). Ship kos calibration at n>=10 pairs." 10
+i "Controlled baseline: naive LLM-over-docs vs graph (finding-023 rubric)" "science,validation,M3" \
+"finding-023's convergent-discovery validation is real — cite it in README. Remaining gap: counterfactual with no graph, same docs, same budget. AC: overlap/precision/unique-yield on 2 projects; README cites both." 11
+i "Test the typed-edge thesis or right-size the taxonomy (92% derives)" "science,schema,M3" \
+"414/450 edges are 'derives'; supports/instantiates/discovered_from have zero uses. Retype 50-edge sample, benchmark traversal value against the ThreeDoors incident-convergence query; sunset-or-defend unused types in schema v0.4. Negative result is bedrock-challenging for val-typed-traversable." 17
+i "Test the instrument: validate/model/drift/charter have zero tests" "code-quality,M1" \
+"12 tests exist, all in process.rs/updater.rs — the self-updater is better tested than the knowledge validator. AC: >=20 tests incl. unknown-edge rejection, dangling detection, graveyard structure, charter render idempotence; malformed fixture fails suite." 18
+i "Truth pass: README/sessions/charter self-description" "docs,M0" \
+"README claims placeholder/ dir (absent); sessions/ holds only session-001 vs ~20 sessions of history; session log embedded in charter. AC: structure matches ls; log extracted; every quantitative README claim cites a finding ID." 19
+```
+
+---
+
+*v2 verdict in one line: the signal-detection layer is real and externally
+corroborated; the integrity layer is unenforced and already leaking; the
+typed-edge and prediction layers are the founding claims still awaiting
+their first honest test. Turn on the gate, then let the failures write the
+worklist.*

--- a/docs/kos-roadmap-v2.md
+++ b/docs/kos-roadmap-v2.md
@@ -1,3 +1,11 @@
+> **SUPERSEDED — historical primary source.** This is roadmap v2
+> (primary-source edition; supersedes [kos-roadmap.md](kos-roadmap.md)).
+> Reassessed by [kos-roadmap-v3.md](kos-roadmap-v3.md), amended by
+> [kos-roadmap-v3_1.md](kos-roadmap-v3_1.md). Authoritative for original
+> intent only; do NOT work from this document — its Part 5 import script
+> was never run and is superseded by scripts/create-roadmap-issues.sh.
+> Current scope lives in v3/v3.1 and the GitHub issues (kos#51–80).
+
 # KOS Assessment & Roadmap v2 — Primary-Source Edition
 
 > Supersedes `kos-roadmap.md` (v1). v1 was built from README, a truncated

--- a/docs/kos-roadmap.md
+++ b/docs/kos-roadmap.md
@@ -1,0 +1,456 @@
+# KOS: Assessment and Recovery Roadmap
+
+> Produced from the founding conversation (sessions 001–present) plus review of
+> github.com/ArcavenAE/kos. Each numbered issue below is written for direct
+> import as a GitHub issue. A `gh` script is at the end.
+> Note: 4 issues already exist on the repo — reconcile before importing.
+
+---
+
+## Part 1 — Assessment
+
+### The concept as it developed
+
+The conversation produced, in order: spec-as-product with epistemic confidence
+tiers (bedrock/frontier/graveyard); a fractal cycle (orient → ideate → question
+→ probe → harvest → promote); graph-over-documents with typed nodes, typed
+edges, and provenance; the shadow principle (documents and code as lossy
+projections of the graph); the correspondence layer (typed spec↔code links);
+the predictor layer (prediction-error as learning signal, the missing fourth
+element of the cognitive architecture); GraphRAG as the query interface; the
+substrate hypothesis (YAML-in-git at a structural ceiling); and finally the
+honest split — two missions were conflated from the start:
+
+1. **Knowledge accumulation and projection** for human-AI teams. Tractable.
+   Evidenced. This is what KOS actually is.
+2. **LLM continuity** ("pearls on a string"). A model-level research problem.
+   Infrastructure alone cannot deliver it. KOS is a precondition for that
+   research, not the research itself.
+
+### The implementation — what's earned
+
+- Empirical validation across 16–21 projects; ~45% consequential signal rate,
+  honestly quantified with a noise breakdown.
+- A stabilized signal taxonomy (contradiction, gap, silent abandonment, drift,
+  AI-config seam, enforcement gap).
+- The graveyard: append-only negative knowledge with finding/ruling/reopener
+  structure. KOS's best feature and its most original contribution.
+- Predictor fields (`predicted_confidence`, `surprise_magnitude`) live in
+  briefs and findings — calibration data is accumulating.
+- Real downstream value: ThreeDoors bootstrap filed actionable issues;
+  finding-019/020 drove a cross-repo refactor; BetterDials tested the method
+  in a foreign domain.
+- The charter renderer (just shipped) exposed 11 silently-broken nodes on its
+  first run — infrastructure catching what prose could not. This is the thesis
+  demonstrated on the project itself.
+
+### The implementation — where it deviated
+
+Root deviation: **the charter became a writable working document instead of a
+regenerated projection.** The regeneration mechanism specified in session-001
+was never built, so the charter absorbed every piece of content that needed to
+be reliably present at session start. Everything else follows from this:
+
+1. **No query layer.** The charter is a cache for queries that don't exist
+   (5-whys root cause, confirmed independently by three analysis voices).
+2. **Soft constraints unenforced.** KOS's own platform finding — "instruction-
+   based enforcement fails; infrastructure enforcement works" — was never
+   applied to KOS itself. Result: 11 schema-drift nodes, charter re-inflation
+   through three compression cycles, cycle-boundary harvest gaps.
+3. **Analysis outpaces artifacts.** The party-of-agents episode produced 30+
+   proposals and zero commits. Insight production has no forcing function
+   converting it to action.
+4. **Single-operator validation.** Every test to date has the author as
+   operator. No control condition exists for the 45% signal claim (naive
+   LLM-over-docs baseline never run). Severity classification is single-rater.
+5. **Calibration data uncollected as science.** The predictor fields exist but
+   no calibration analysis has ever been run on them.
+6. **Distributed evidence is illegible.** 227 nodes across 9 repos with no
+   cross-repo traversal; an outside reader cannot reconstruct project state
+   from artifacts alone.
+
+### The recovery principle
+
+Every fix below converts a discipline problem into an infrastructure
+guarantee, or converts a claim into a measurement. Nothing below is a process
+exhortation. The project has proven it cannot hold soft constraints; it has
+also proven infrastructure catches what prose hides. Build accordingly.
+
+---
+
+## Part 2 — Roadmap
+
+Milestones are sequential. Issues within a milestone can run in parallel
+unless a dependency is stated. Every issue closes with a commit, not a
+document.
+
+---
+
+### Milestone 0 — Restore the architecture (charter as projection)
+
+#### Issue 1: Fix the 11 schema-drift nodes
+
+**Labels:** `bug`, `schema`, `M0`
+
+The `kos charter render` first run skipped 11 frontier nodes that fail
+deserialization: 7 use undefined edge types (`relates` ×4, `related` ×2,
+`depends` ×2, `resolves-partially` ×1), 2 have `provenance` as a YAML sequence
+instead of a struct.
+
+**Deliverables:** Corrected node files; decision recorded per undefined edge
+type (map to existing type, or add to schema with definition); re-run renderer.
+
+**Acceptance:** `kos validate` passes on all graphs; rendered charter includes
+all frontier nodes; a finding node records which violations existed and how
+each was resolved.
+
+---
+
+#### Issue 2: Classify charter-only content
+
+**Labels:** `charter`, `M0`
+**Depends on:** Issue 1
+
+The diff between rendered output (247 lines) and hand-maintained charter
+(~1100 lines) is the inventory of content with no node home: preamble
+(problem statement, values, non-goals), operating posture, "how this document
+is used," session log, research notes pointer, plus prose bodies on F-items.
+
+**Deliverables:** Every charter-only span classified as exactly one of:
+(a) becomes a node, (b) becomes static preamble in the renderer,
+(c) discarded with one-line rationale in the commit message.
+
+**Acceptance:** Zero unclassified content; nodes created for (a); renderer
+preamble updated for (b); classification recorded as a finding.
+
+---
+
+#### Issue 3: Cut over to rendered charter; forbid hand-edits
+
+**Labels:** `charter`, `infrastructure`, `M0`
+**Depends on:** Issue 2
+
+**Deliverables:** `kos charter render --write` becomes the only sanctioned
+write path to charter.md. Pre-commit hook (lefthook) compares charter.md
+against fresh render output; mismatch fails the commit with "edit nodes, not
+the projection."
+
+**Acceptance:** Hand-editing charter.md is structurally blocked; harvest
+protocol in CLAUDE.md updated to end with the render step; one full cycle
+completed under the new regime.
+
+---
+
+### Milestone 1 — Infrastructure-enforced discipline
+
+#### Issue 4: Schema validation as a hard pre-commit gate
+
+**Labels:** `infrastructure`, `schema`, `M1`
+
+The 11-node drift class must become structurally impossible, in every graph,
+not just kos's.
+
+**Deliverables:** `kos validate` wired into lefthook pre-commit across all
+9 graphs; edge-type whitelist enforced; provenance shape enforced;
+unknown-field warnings.
+
+**Acceptance:** A deliberately malformed node cannot be committed anywhere on
+the platform.
+
+---
+
+#### Issue 5: Context budget accounting and eager-import removal
+
+**Labels:** `infrastructure`, `context`, `M1`
+
+Sessions pay an unmeasured, unconditional context tax. The orc CLAUDE.md
+eagerly @-imports subrepo CLAUDE.mds that Claude Code's per-cwd resolution
+already handles.
+
+**Deliverables:** (a) `scripts/claudemd-budget.sh` — token estimate per
+@-import, total, flags over threshold. (b) Remove subrepo CLAUDE.md @-imports
+from orc. (c) Log budget for 5 sessions before any further pruning — measure,
+then cut.
+
+**Acceptance:** Budget report exists in-repo; eager imports removed; before/
+after token cost recorded as a finding.
+
+---
+
+#### Issue 6: Artifact-close rule for the cycle
+
+**Labels:** `process`, `M1`
+
+Harvest currently accepts prose findings without committed artifacts —
+analysis-only sessions close cycles they shouldn't.
+
+**Deliverables:** CLAUDE.md session protocol amended: a cycle closes only on
+a commit touching code, schema, or node files. Two consecutive analysis-only
+sessions trigger a mandatory graveyard review of the current line of work.
+Where checkable (commit present in session window), enforce via the harvest
+checklist script.
+
+**Acceptance:** Rule live in protocol; first enforcement instance (pass or
+triggered review) recorded.
+
+---
+
+### Milestone 2 — Query layer MVP (kill the cache)
+
+#### Issue 7: Define the subgraph context format
+
+**Labels:** `design`, `query`, `M2`
+
+Spec before engine. The format is what every query command emits and what
+agents consume: node id, type, confidence, summary, typed edges with targets
+and confidence, provenance pointer, staleness flag.
+
+**Deliverables:** `docs/subgraph-context-format.md` with schema and 3 worked
+examples hand-produced from the ThreeDoors graph; validated by using one
+example to answer a real question in-session.
+
+**Acceptance:** Format doc merged; the hand-produced examples demonstrably
+improved an answer vs. charter-only context (record as finding).
+
+---
+
+#### Issue 8: Core query commands
+
+**Labels:** `cli`, `query`, `M2`
+**Depends on:** Issue 7
+
+**Deliverables:** `kos frontier --active`, `kos bedrock [--tag <area>]`,
+`kos recent --since <n>d`, each emitting the subgraph context format
+(plus `--human` for prose).
+
+**Acceptance:** Each command answers its question from the graph in <1s on the
+227-node platform; output validates against the format.
+
+---
+
+#### Issue 9: Task-conditional orientation
+
+**Labels:** `cli`, `query`, `M2`
+**Depends on:** Issue 8
+
+**Deliverables:** `kos orient --for=<task>` — scope-tagged retrieval returning
+the relevant bundle (bedrock in scope, active frontier in scope, recent
+findings touching scope). Frontier nodes gain a `scope:` tag as needed.
+
+**Acceptance:** A session in one subrepo orients via the command instead of
+loading the full charter; token cost vs. charter load measured and recorded.
+This is the empirical test of the "charter is a cache" hypothesis — the
+finding stands regardless of which way it goes.
+
+---
+
+### Milestone 3 — Scientific rigor
+
+#### Issue 10: Calibration pipeline and scheduled review
+
+**Labels:** `science`, `predictor`, `M3`
+
+Prediction fields exist; the science doesn't. Pre-registration discipline:
+`predicted_confidence` is written before the probe and never revised —
+enforce via the validate gate (Issue 4: reject edits to that field on
+existing briefs).
+
+**Deliverables:** `predicted_confidence` required on all new briefs;
+`surprise_magnitude` required on all new findings; `kos calibration` —
+tabulates prediction vs. outcome, flags systematic over/under-confidence.
+Review every 5 sessions, results committed as findings.
+
+**Acceptance:** First calibration report produced from the ≥9 existing
+brief/finding pairs plus new ones; one concrete adjustment made based on it.
+
+---
+
+#### Issue 11: Controlled baseline for the signal claim
+
+**Labels:** `science`, `validation`, `M3`
+
+The 45%-consequential claim has no control condition. Measure KOS's marginal
+value over the obvious alternative.
+
+**Deliverables:** On 2 previously-probed projects, run a naive baseline —
+LLM over the raw documents, no graph, same time budget — and score its
+findings with the same severity rubric. Compare yield, precision, and overlap
+against the KOS results.
+
+**Acceptance:** Comparison committed as a finding. If the baseline matches
+KOS, that is a bedrock-challenging result and gets treated as one. README
+claims updated to cite the controlled result.
+
+---
+
+#### Issue 12: Inter-rater reliability on severity classification
+
+**Labels:** `science`, `validation`, `M3`
+
+Consequential/low-impact/noise is currently single-rater (the author).
+
+**Deliverables:** Blind second rating of a 30-finding sample (second human or
+independent agent session with no access to original ratings); agreement
+statistic computed; rubric tightened where disagreement clusters.
+
+**Acceptance:** Agreement measured and published; rubric v2 committed if
+agreement < 0.7.
+
+---
+
+#### Issue 13: External-operator probe
+
+**Labels:** `science`, `validation`, `M3`
+**Depends on:** Issues 3, 8
+
+The strongest untested claim: artifacts alone can orient a stranger.
+
+**Deliverables:** One person who has never been in a session runs `kos init`
++ `kos orient` on their own repo, and separately reads the kos repo cold and
+writes what the project is, what it produced, and what's next. Both recorded
+verbatim.
+
+**Acceptance:** The gap between their account and actual state is committed
+as a finding — that gap is the measured communication debt. No coaching
+during the probe.
+
+---
+
+#### Issue 14: Scheduled graveyard audit
+
+**Labels:** `process`, `M3`
+
+Self-pruning happens ad hoc; it must be load-bearing.
+
+**Deliverables:** Every 3rd session includes a graveyard audit: propose 3
+candidates (assumptions, scope items, or stale frontier questions — sunset
+rule: frontier with no probe activity in 10 sessions is automatically a
+candidate), accept or reject each with explicit reasoning, commit accepted
+entries. F1 (Director Design, frontier since session-001) is the first test
+case.
+
+**Acceptance:** First audit completed and committed; cadence recorded in
+CLAUDE.md protocol.
+
+---
+
+### Milestone 4 — Substrate research track (gated on M0–M2)
+
+#### Issue 15: Substrate property probes
+
+**Labels:** `research`, `substrate`, `M4`
+
+The substrate hypothesis names five properties files cannot provide:
+first-class relationships, preserved reasoning chains, on-demand projection,
+session-surviving context, concurrent transaction semantics. Do not choose a
+substrate; test one property at a time.
+
+**Deliverables:** One probe per property, each with a brief
+(`predicted_confidence` required), tested against the ThreeDoors 104-node
+graph. Candidates: SQLite+graph layer, Dolt, XTDB/Datomic-class store,
+git-DAG-direct (no file presentation layer). Timebox per probe: one session.
+
+**Acceptance:** Each probe produces a finding or a graveyard entry. No
+substrate migration begins until ≥3 properties have empirical results.
+
+---
+
+### Milestone 5 — Mission clarity
+
+#### Issue 16: Split the missions; graveyard the conflation
+
+**Labels:** `charter`, `mission`, `M5`
+
+**Deliverables:** (a) Graveyard entry: `grv-continuity-via-infrastructure` —
+ruled out; LLM continuity requires model-level mechanisms (persistent-state
+inference, graph-native training); reopener: when such mechanisms exist, KOS
+is the substrate they operate on. (b) Mission restated in charter preamble:
+KOS is a knowledge accumulation and projection system for human-AI teams.
+(c) Continuity tracked as a named external research dependency, not an
+implied KOS property.
+
+**Acceptance:** Graveyard entry committed; rendered charter reflects the
+restated mission; README updated to match.
+
+---
+
+## Part 3 — Sequencing and forcing function
+
+```
+Session n:    Issues 1, 2          (schema fix, classification)
+Session n+1:  Issue 3              (cutover — architecture restored)
+Session n+2:  Issues 4, 5          (gates, budget)
+Session n+3:  Issues 6, 7          (artifact rule, format spec)
+Session n+4:  Issue 8              (query commands)
+Session n+5:  Issues 9, 14         (task orient, first graveyard audit)
+Session n+6:  Issue 10             (first calibration report)
+Then:         11, 12, 13 as capacity allows; 15 gated on 0–2; 16 anytime
+```
+
+Standing rule for the whole roadmap: **each issue closes with a commit.**
+Findings about issues do not close issues. If a session produces only
+analysis, the cycle did not close.
+
+---
+
+## Part 4 — Import script
+
+Requires `gh` authenticated to ArcavenAE/kos. Bodies reference this file —
+commit it to the repo first (suggested path: `docs/roadmap-2026-07.md`).
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+R="ArcavenAE/kos"
+D="docs/roadmap-2026-07.md"
+
+gh label create M0 --repo $R --color 0e8a16 --force
+gh label create M1 --repo $R --color 0e8a16 --force
+gh label create M2 --repo $R --color 1d76db --force
+gh label create M3 --repo $R --color 5319e7 --force
+gh label create M4 --repo $R --color b60205 --force
+gh label create M5 --repo $R --color fbca04 --force
+gh label create science --repo $R --color 5319e7 --force
+
+i() { gh issue create --repo $R --title "$1" --label "$2" --body "$3
+
+Full spec: $D (Issue $4)"; }
+
+i "Fix 11 schema-drift nodes (undefined edge types, provenance shape)" "bug,schema,M0" \
+  "7 nodes use undefined edge types (relates, related, depends, resolves-partially); 2 have provenance as sequence. Invisible until the renderer parsed them. AC: kos validate passes everywhere; finding records each resolution." 1
+i "Classify charter-only content: node / preamble / discard" "M0" \
+  "Diff rendered charter (247 lines) vs hand-maintained (~1100). Every span gets exactly one classification. AC: zero unclassified; finding committed." 2
+i "Cut over to rendered charter; block hand-edits via pre-commit" "M0" \
+  "charter render --write is the only write path. Lefthook compares charter.md to fresh render; mismatch fails commit. AC: hand-editing structurally blocked; one cycle completed under new regime." 3
+i "kos validate as hard pre-commit gate across all 9 graphs" "M1,schema" \
+  "Edge-type whitelist, provenance shape, unknown-field warnings. AC: malformed node cannot be committed anywhere." 4
+i "Context budget accounting; remove eager subrepo CLAUDE.md imports" "M1" \
+  "Token estimate per @-import; remove orc's eager subrepo imports (per-cwd resolution handles it). Measure 5 sessions before further cuts. AC: before/after cost recorded as finding." 5
+i "Artifact-close rule: cycles close on commits, not prose" "M1" \
+  "Cycle closes only on commit touching code/schema/nodes. Two analysis-only sessions trigger graveyard review. AC: rule live; first enforcement recorded." 6
+i "Define subgraph context format (spec before engine)" "M2" \
+  "docs/subgraph-context-format.md + 3 hand-built examples from ThreeDoors graph. AC: one example demonstrably improves an in-session answer; recorded as finding." 7
+i "Query commands: kos frontier / bedrock / recent" "M2" \
+  "Each emits subgraph context format; --human for prose. AC: <1s on 227-node platform; output validates." 8
+i "kos orient --for=<task> — task-conditional context bundle" "M2" \
+  "Scope-tagged retrieval replaces full-charter load for subrepo sessions. AC: token cost vs charter load measured — empirical test of the charter-as-cache hypothesis." 9
+i "Calibration pipeline: enforce prediction fields, ship kos calibration" "M3,science" \
+  "predicted_confidence required pre-probe and immutable; surprise_magnitude required at harvest; report every 5 sessions. AC: first report from existing pairs; one adjustment made from it." 10
+i "Controlled baseline for the 45% signal claim" "M3,science" \
+  "Naive LLM-over-docs on 2 previously-probed projects, same rubric, same time budget. AC: comparison committed; README cites controlled result. If baseline matches KOS, treat as bedrock-challenging." 11
+i "Inter-rater reliability on severity classification" "M3,science" \
+  "Blind second rating of 30-finding sample; agreement statistic; rubric v2 if <0.7. AC: agreement published." 12
+i "External-operator probe: stranger runs init/orient uncoached" "M3,science" \
+  "One outside person, their repo, no coaching; plus cold-read of the kos repo. AC: gap between their account and actual state committed as the measured communication debt." 13
+i "Scheduled graveyard audit every 3 sessions" "M3" \
+  "3 candidates per audit, accept/reject with reasoning. Sunset rule: frontier with no probe activity in 10 sessions is auto-candidate. F1 is the first test case. AC: first audit committed; cadence in protocol." 14
+i "Substrate property probes (one property per probe)" "M4,research" \
+  "Five properties, tested one at a time against ThreeDoors graph. Candidates: SQLite+graph, Dolt, XTDB-class, git-DAG-direct. AC: finding or graveyard per probe; no migration until 3+ properties have results." 15
+i "Split the missions: graveyard continuity-via-infrastructure" "M5" \
+  "grv-continuity-via-infrastructure with reopener (model-level mechanisms). Mission restated: knowledge accumulation + projection for human-AI teams. AC: graveyard committed; charter and README updated." 16
+```
+
+---
+
+*End of roadmap. The measure of this document is how fast it stops being read
+and starts being closed.*

--- a/docs/kos-roadmap.md
+++ b/docs/kos-roadmap.md
@@ -1,3 +1,11 @@
+> **SUPERSEDED — historical primary source.** This is roadmap v1
+> (unversioned original). Revised by [kos-roadmap-v2.md](kos-roadmap-v2.md)
+> (items 1, 4, 10, 11 revised; 17–19 added), reassessed by
+> [kos-roadmap-v3.md](kos-roadmap-v3.md), amended by
+> [kos-roadmap-v3_1.md](kos-roadmap-v3_1.md). Authoritative for original
+> intent only; do NOT work from this document. Current scope lives in
+> v3/v3.1 and the GitHub issues (kos#51–80).
+
 # KOS: Assessment and Recovery Roadmap
 
 > Produced from the founding conversation (sessions 001–present) plus review of


### PR DESCRIPTION
Adds the two previously-unsourced ancestors of the committed roadmap v3/v3.1:

- `docs/kos-roadmap.md` — v1, full-text specs for items 2, 3, 5–9, 12–16 + the v1 import script
- `docs/kos-roadmap-v2.md` — primary-source edition; revised items 1, 4, 10, 11, new 17–19, revised sequencing, and the Part 5 import script (the gh-issue script flagged at the start of the research-drop review)

Issues #51–63 were reconstructed from v3's one-line "v2 stands" summaries before these originals were available. With this PR merged, each of those issues gets a retrofit comment quoting its original spec text, marked authoritative for intent (v3/v3.1 amendments remain authoritative for scope changes).

Not included: `docs/Mapping KOS to Prior Work_...` (byte-identical duplicate of the committed `kos-prior-work-survey.md`; left untracked for operator removal).