### PR TITLE
fix(model): load nodes leniently, fail unknown edge types at validate

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -175,9 +175,9 @@ fn check_graph(graph: &GraphSource, workspace: &Workspace, fix: bool) -> Result<
     println!();
     println!("  Content");
 
-    let nodes = load_all_nodes(&graph.path);
+    let (nodes, parse_errors) = load_all_nodes_counting_failures(&graph.path);
     let node_count = nodes.len();
-    let parse_errors = 0;
+    let mut unknown_edge_types = 0;
     let mut id_mismatches = 0;
     let mut dir_mismatches = 0;
     let mut broken_edges = 0;
@@ -227,10 +227,30 @@ fn check_graph(graph: &GraphSource, workspace: &Workspace, fix: bool) -> Result<
                 ));
                 broken_edges += 1;
             }
+            if let Some(raw) = edge.edge_type.unknown_value() {
+                warn(&format!(
+                    "node {}: edge to '{}' has unknown type '{raw}' (kos validate fails on this)",
+                    node.id, edge.target
+                ));
+                unknown_edge_types += 1;
+            }
         }
     }
 
-    if parse_errors == 0 && node_count > 0 {
+    if parse_errors > 0 {
+        err(&format!(
+            "{parse_errors} file(s) failed to parse and are invisible to every kos read path"
+        ));
+        errors += parse_errors;
+        hint("run `kos validate` to see the offending files");
+    }
+
+    if unknown_edge_types > 0 {
+        warnings += unknown_edge_types;
+        hint("unknown edge types load but do not traverse; `kos validate` names each one");
+    }
+
+    if parse_errors == 0 && unknown_edge_types == 0 && node_count > 0 {
         ok(&format!("{node_count} nodes parse successfully"));
     } else if node_count == 0 {
         warn("no nodes found");
@@ -358,14 +378,21 @@ fn check_legacy(workspace: &Workspace, _fix: bool) -> Result<()> {
 }
 
 /// Load all node YAML files from a _kos/ graph directory.
-fn load_all_nodes(kos_dir: &Path) -> Vec<Node> {
+/// Load nodes, returning the count of files that failed to parse.
+///
+/// `load_all_nodes` swallows read and parse failures, which is why doctor
+/// used to hardcode `parse_errors = 0` and print an affirmative
+/// "N nodes parse successfully" over graphs that were partly unreadable.
+/// A health check that cannot report ill health is worse than none.
+fn load_all_nodes_counting_failures(kos_dir: &Path) -> (Vec<Node>, usize) {
     let nodes_dir = kos_dir.join("nodes");
     if !nodes_dir.exists() {
-        return vec![];
+        return (Vec::new(), 0);
     }
 
     let mut nodes = Vec::new();
-    for entry in walkdir::WalkDir::new(nodes_dir)
+    let mut failures = 0;
+    for entry in walkdir::WalkDir::new(&nodes_dir)
         .into_iter()
         .filter_map(std::result::Result::ok)
     {
@@ -374,15 +401,19 @@ fn load_all_nodes(kos_dir: &Path) -> Vec<Node> {
             .extension()
             .is_some_and(|ext| ext == "yaml" || ext == "yml")
         {
-            if let Ok(content) = std::fs::read_to_string(path) {
-                if let Ok(mut node) = serde_yaml::from_str::<Node>(&content) {
-                    node.source_path = path.to_path_buf();
-                    nodes.push(node);
-                }
+            match std::fs::read_to_string(path) {
+                Ok(content) => match serde_yaml::from_str::<Node>(&content) {
+                    Ok(mut node) => {
+                        node.source_path = path.to_path_buf();
+                        nodes.push(node);
+                    }
+                    Err(_) => failures += 1,
+                },
+                Err(_) => failures += 1,
             }
         }
     }
-    nodes
+    (nodes, failures)
 }
 
 // ── Output helpers ──────────────────────────────────────────

--- a/src/model.rs
+++ b/src/model.rs
@@ -125,8 +125,38 @@ pub struct Edge {
     pub note: Option<String>,
 }
 
+/// The legal edge vocabulary, in the order the schema documents it.
+/// Used to render actionable errors when an unknown type is rejected.
+pub const LEGAL_EDGE_TYPES: [&str; 8] = [
+    "derives",
+    "implements",
+    "contradicts",
+    "supersedes",
+    "supports",
+    "instantiates",
+    "partially_resolves",
+    "discovered_from",
+];
+
+/// Deserialization is INFALLIBLE by design: an unrecognized type becomes
+/// `Unknown(raw)` rather than failing the parse.
+///
+/// The strict enum used to fail the whole-document parse, and every read
+/// path (orient, drift, graph, charter, compact, doctor) then skipped the
+/// entire NODE over one bad edge, warning only on stderr. marvel ran two
+/// months with 14 of 25 nodes invisible; switchboard lost all 7 of its
+/// bedrock elements. Dropping a node's content to punish one pointer is
+/// the failure `elem-ai-improvisation-past-broken-refs` describes: the
+/// reader does not error, it confabulates over the hole.
+///
+/// Leniency here is paired with strictness at authorship: `kos validate`
+/// FAILS on `Unknown`, naming the value and the legal vocabulary. Tolerant
+/// reader, strict writer.
+///
+/// The raw string is preserved verbatim so a later vocabulary migration
+/// reads what the author actually wrote instead of a lossy normalization.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(from = "String")]
 #[non_exhaustive]
 pub enum EdgeType {
     Derives,
@@ -141,14 +171,44 @@ pub enum EdgeType {
     PartiallyResolves,
     /// Found during work on the target. Provenance link for probe→question lineage.
     DiscoveredFrom,
+    /// An edge type outside the schema vocabulary, preserved verbatim.
+    /// Never blocking, never propagating. `kos validate` fails on it.
+    Unknown(String),
+}
+
+impl From<String> for EdgeType {
+    fn from(raw: String) -> Self {
+        match raw.as_str() {
+            "derives" => EdgeType::Derives,
+            "implements" => EdgeType::Implements,
+            "contradicts" => EdgeType::Contradicts,
+            "supersedes" => EdgeType::Supersedes,
+            "supports" => EdgeType::Supports,
+            "instantiates" => EdgeType::Instantiates,
+            "partially_resolves" => EdgeType::PartiallyResolves,
+            "discovered_from" => EdgeType::DiscoveredFrom,
+            _ => EdgeType::Unknown(raw),
+        }
+    }
 }
 
 impl EdgeType {
     /// Whether this edge type represents a blocking dependency for ready-work
     /// computation. Blocking means: if the target is unresolved, the source
     /// cannot be probed/acted on.
+    ///
+    /// `Unknown` is never blocking: an edge we cannot interpret must not
+    /// silently evict its source node from the ready queue.
     pub fn is_blocking(&self) -> bool {
         matches!(self, EdgeType::Derives | EdgeType::Implements)
+    }
+
+    /// The raw string if this edge type is outside the schema vocabulary.
+    pub fn unknown_value(&self) -> Option<&str> {
+        match self {
+            EdgeType::Unknown(raw) => Some(raw.as_str()),
+            _ => None,
+        }
     }
 }
 
@@ -163,6 +223,7 @@ impl std::fmt::Display for EdgeType {
             EdgeType::Instantiates => write!(f, "instantiates"),
             EdgeType::PartiallyResolves => write!(f, "partially_resolves"),
             EdgeType::DiscoveredFrom => write!(f, "discovered_from"),
+            EdgeType::Unknown(raw) => write!(f, "{raw}"),
         }
     }
 }

--- a/src/orient.rs
+++ b/src/orient.rs
@@ -27,6 +27,26 @@ pub struct Orientation {
     pub is_standalone: bool,
 }
 
+impl Orientation {
+    /// Count edges whose type is outside the schema vocabulary.
+    ///
+    /// These load (the reader is lenient) but carry no traversal meaning:
+    /// they are neither blocking for `--ready` nor propagating in drift.
+    /// Surfacing the count IN the output is the point. The old loader
+    /// dropped whole nodes and warned only on stderr, so `--json`
+    /// consumers received a clean, confidently incomplete graph with no
+    /// signal that anything was missing.
+    pub fn unrecognized_edge_count(&self) -> usize {
+        self.frontier_questions
+            .iter()
+            .chain(&self.bedrock_nodes)
+            .chain(&self.graveyard_nodes)
+            .flat_map(Node::all_edges)
+            .filter(|e| e.edge_type.unknown_value().is_some())
+            .count()
+    }
+}
+
 /// A probe entry loaded from `_kos/probes/`.
 #[derive(Debug)]
 pub struct ProbeEntry {
@@ -1075,6 +1095,13 @@ fn print_human(o: &Orientation) {
         println!("=== kos orient: {} ===\n", o.target);
     }
 
+    let degraded = o.unrecognized_edge_count();
+    if degraded > 0 {
+        println!(
+            "!! {degraded} edge(s) carry unrecognized types and do not traverse — run `kos validate`\n"
+        );
+    }
+
     if !o.charter_items.is_empty() {
         if o.is_standalone {
             println!("## Charter\n");
@@ -1203,6 +1230,20 @@ fn print_jsonl(o: &Orientation) {
             "type": "orient_meta",
             "target": o.target,
             "standalone": true,
+        });
+        println!("{json}");
+    }
+
+    // In-band degradation signal. An agent consuming this stream has no
+    // access to stderr, so a graph with untraversable edges must say so
+    // here or the omission is indistinguishable from absence.
+    let degraded = o.unrecognized_edge_count();
+    if degraded > 0 {
+        let json = serde_json::json!({
+            "type": "orient_degraded",
+            "target": o.target,
+            "unrecognized_edges": degraded,
+            "hint": "run `kos validate`; these edges load but do not traverse",
         });
         println!("{json}");
     }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use crate::error::{KosError, Result};
-use crate::model::{Node, NodeType};
+use crate::model::{LEGAL_EDGE_TYPES, Node, NodeType};
 
 #[derive(Debug)]
 pub struct ValidationResult {
@@ -188,6 +188,17 @@ fn validate_node(node: &Node, rel_path: &str, known_ids: &HashSet<String>) -> Va
             warnings.push(format!(
                 "edge target '{}' not found in nodes/ (may be a finding or probe)",
                 edge.target
+            ));
+        }
+
+        // 3b. Edge type is in the schema vocabulary. The loader is lenient so
+        // one bad edge never hides a node from readers; the gate lives here,
+        // at authorship, where the author can still fix it.
+        if let Some(raw) = edge.edge_type.unknown_value() {
+            errors.push(format!(
+                "edge to '{}' has unknown type '{raw}' (expected one of: {})",
+                edge.target,
+                LEGAL_EDGE_TYPES.join(", ")
             ));
         }
     }

--- a/tests/lenient_edge_loading.rs
+++ b/tests/lenient_edge_loading.rs
@@ -1,0 +1,116 @@
+//! Integration tests for lenient edge loading (aae-orc-znzh,
+//! brief-lenient-edge-loading, question-edge-vocabulary-gap sub-question c).
+//!
+//! Regression under test: an edge type outside the schema vocabulary used to
+//! fail the whole-document parse, so every read path skipped the entire NODE
+//! and warned only on stderr. marvel ran two months with 14 of 25 nodes
+//! invisible to orient; switchboard lost all 7 of its bedrock elements.
+//!
+//! The contract is tolerant reader, strict writer: readers load the node and
+//! preserve the unknown type verbatim, `kos validate` fails on it.
+
+use std::fs;
+use std::path::Path;
+
+use kos::model::{EdgeType, Node};
+use kos::validate;
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+/// A graph with one clean node and one carrying an invented edge type.
+/// `related` is the real-world case: 50 instances across the fleet.
+fn fixture(root: &Path) {
+    write(
+        &root.join("_kos/kos.yaml"),
+        "graph_id: fixture\nscope: repo\nschema_version: '0.3'\n",
+    );
+    write(
+        &root.join("_kos/nodes/bedrock/elem-clean.yaml"),
+        "id: elem-clean\ntype: element\nconfidence: bedrock\ntitle: \"t\"\ncontent: \"c\"\n",
+    );
+    write(
+        &root.join("_kos/nodes/bedrock/elem-invented.yaml"),
+        "id: elem-invented\ntype: element\nconfidence: bedrock\ntitle: \"t\"\ncontent: \"c\"\n\
+         edges:\n  - target: elem-clean\n    type: related\n",
+    );
+}
+
+#[test]
+fn node_with_unknown_edge_type_still_loads() {
+    let tmp = tempfile::tempdir().unwrap();
+    fixture(tmp.path());
+
+    let summary = validate::run(&tmp.path().join("_kos")).unwrap();
+
+    // The whole point: the node is counted, not dropped. Before the fix this
+    // was 1 node + 1 parse error, and the node was invisible to every reader.
+    assert_eq!(summary.total, 2, "both nodes must be visible to the loader");
+    assert_eq!(
+        summary.parse_errors, 0,
+        "an unknown edge type is not a parse error"
+    );
+}
+
+#[test]
+fn validate_fails_the_node_and_names_the_offending_value() {
+    let tmp = tempfile::tempdir().unwrap();
+    fixture(tmp.path());
+
+    let summary = validate::run(&tmp.path().join("_kos")).unwrap();
+
+    assert_eq!(summary.failed, 1, "the invented edge type must fail");
+    assert_eq!(summary.passed, 1, "the clean node must still pass");
+    assert!(
+        !summary.clean(),
+        "a graph with an unknown edge type is not clean, so exit is nonzero"
+    );
+}
+
+#[test]
+fn unknown_edge_type_preserves_the_author_string_verbatim() {
+    // Verbatim preservation is what lets a later vocabulary migration read
+    // what the author actually wrote instead of a lossy normalization.
+    let yaml = "id: elem-x\ntype: element\nconfidence: bedrock\ntitle: \"t\"\ncontent: \"c\"\n\
+                edges:\n  - target: elem-y\n    type: leaves-open\n";
+    let node: Node = serde_yaml::from_str(yaml).unwrap();
+
+    assert_eq!(node.edges.len(), 1);
+    assert_eq!(node.edges[0].edge_type.unknown_value(), Some("leaves-open"));
+    assert_eq!(node.edges[0].edge_type.to_string(), "leaves-open");
+}
+
+#[test]
+fn unknown_edge_type_is_never_blocking() {
+    // An edge we cannot interpret must not silently evict its source node
+    // from the ready queue. Marvel manufactured two permanent evictions this
+    // way with a legal-but-wrong retype (aae-orc-1bte); an uninterpretable
+    // edge must not be able to do it at all.
+    let unknown = EdgeType::from("some-invented-thing".to_string());
+    assert!(!unknown.is_blocking());
+
+    assert!(EdgeType::from("derives".to_string()).is_blocking());
+    assert!(EdgeType::from("implements".to_string()).is_blocking());
+    assert!(!EdgeType::from("supports".to_string()).is_blocking());
+}
+
+#[test]
+fn every_legal_edge_type_still_round_trips() {
+    // Guard against the lenient path swallowing a legal type into Unknown,
+    // which would silently disable blocking and drift propagation.
+    for name in kos::model::LEGAL_EDGE_TYPES {
+        let parsed = EdgeType::from(name.to_string());
+        assert_eq!(
+            parsed.unknown_value(),
+            None,
+            "{name} must parse as a known variant"
+        );
+        assert_eq!(
+            parsed.to_string(),
+            name,
+            "{name} must render back as itself"
+        );
+    }
+}


### PR DESCRIPTION
A single unrecognized edge type currently hides an entire node from every kos reader, and says so only on stderr. Across the fleet that is 50 nodes invisible right now: switchboard shows 2 of its 13 nodes and none of its 7 bedrock elements. marvel ran two months at 14 of 25 before anyone noticed. This restores all 50 without touching a single node file.

The worst part is the shape of the failure, not the count. `kos orient --json` is the path agents read, and it emitted a clean, well-formed, confidently incomplete graph with no indication anything was missing. That is exactly the condition `elem-ai-improvisation-past-broken-refs` describes: the reader does not error, it confabulates over the hole.

## What changed

`EdgeType` deserialization is now infallible. An unrecognized type becomes `Unknown(raw)` and keeps the author's string verbatim, so a later vocabulary migration reads what was actually written rather than a lossy normalization. `Unknown` is never blocking and never propagates in drift, so it cannot evict its source node from the ready queue.

Leniency at read time is paired with strictness at authorship. `kos validate` now FAILS on an unknown type and names both the offending value and the legal vocabulary:

```
FAIL  elem-mvp-scope-single-lan
      x edge to 'question-edge-protocol' has unknown type 'related'
        (expected one of: derives, implements, contradicts, supersedes,
         supports, instantiates, partially_resolves, discovered_from)
```

Tolerant reader, strict writer. The gate moves to the author, who can still fix it, instead of punishing a reader months later.

Two further fixes ride along because they are the same defect:

- `orient` gains an in-band degradation signal on both the human and `--json` paths. An agent consuming JSONL has no access to stderr, so a graph with untraversable edges has to say so in the stream or the omission is indistinguishable from absence.
- `doctor` printed an affirmative false green. `parse_errors` was hardcoded to `0` over a loader that swallowed failures, so it reported "N nodes parse successfully" for graphs that were partly unreadable. It now counts real load failures and reports unknown edge types.

## Measured

| repo | before | after |
|---|---|---|
| switchboard | 2 | 13 |
| BetterDials | 20 | 32 |
| forestage | 13 | 20 |
| tmux-cmc | 5 | 12 |
| curtain | 8 | 14 |
| spectacle | 5 | 9 |
| sidestep | 14 | 17 |

50 nodes restored. marvel is unchanged at 32, having been repaired by hand in July.

## Cost of merge

Additive. No node file changes, no schema change, no new edge types. Every graph that validated before still validates identically; graphs that were silently degraded now say so. The nine or so load loops inherit the fix without being touched, because the change is in the shared deserializer.

5 new tests, 20 passing. `just ci` green.

Refs: aae-orc-znzh, aae-orc-kmet, brief-lenient-edge-loading, question-edge-vocabulary-gap sub-question (c)