### PR TITLE
harvest: question-edge-vocabulary-gap — adjudicated, eight types stand, see finding-044

### DIFF
--- a/_kos/findings/finding-044-edge-vocabulary-adjudicated.yaml
+++ b/_kos/findings/finding-044-edge-vocabulary-adjudicated.yaml
@@ -1,0 +1,232 @@
+id: finding-044-edge-vocabulary-adjudicated
+type: finding
+confidence: frontier
+title: "Edge vocabulary adjudicated: eight types stand, the loader was the real defect, and the demand premise was false"
+content: |
+  ## Summary
+
+  `question-edge-vocabulary-gap` asked whether v0.3's edge vocabulary needs a
+  weak-association type (`relates_to`) and a scope-exclusion type
+  (`leaves_open`). Adjudicated 2026-08-08/09. **The eight types stand. No new
+  edge types.** The scope-exclusion semantic lands as a node FIELD
+  (`out_of_scope`), not an edge. The loader failure mode, sub-question (c),
+  shipped independently and was the largest real defect in the whole area.
+
+  The question's central evidentiary claim did not survive measurement, which
+  is the most reusable part of this finding.
+
+  ## Method
+
+  Fifteen agents: four research lenses (kos intent from vision/charter/roadmap;
+  kos mechanics from source; knowledge-representation literature; retrieval
+  literature plus empirical measurement of the live fleet graph), four argued
+  positions (legalize-both, normalize-eight, split-ruling, restructure), four
+  adversarial cross-examinations each casting an independent verdict, two live
+  simulations against real data, and a synthesis that tallied the vote and
+  preserved dissent.
+
+  Vote: **3 of 4 for normalize-eight, all at high confidence.** normalize-eight
+  was the only position to survive its own cross-examination.
+
+  ## The premise that failed
+
+  The question claimed the invented types were "convergent, multiple repos,
+  independent authors" and treated that as evidence of real schema demand.
+
+  Measured: 48 of the 50 offending nodes were last modified on or before
+  2026-05-13, and 39 on that single day. That day was one fleet-wide
+  charter-extraction campaign, run in a single session across switchboard
+  (c5b4c22), BetterDials (0c64d60), forestage (d277a3a), curtain (71460da),
+  spectacle (8d9a9bd) and sidestep (2985c6b), every commit of the form
+  `harvest(kos): extract ... from charter`.
+
+  The repos are multiple. The authors and the session are not. This is one
+  habit copied six times, not distributed demand. A later pass narrowed it
+  further: at least three authoring sessions total (tmux-cmc's cluster dates
+  to 2026-04-02, sidestep's `cousin` to 2026-05-03), but the convergence claim
+  stays dead either way.
+
+  Corroborating trend, orc graph from git history: illegal-edge ratio fell
+  from 9% (2026-04-28) to 2% (May, June) to 0% (July, August), with 32 edges
+  authored in the last three weeks and zero illegal. Authors comply with the
+  eight-type vocabulary once they know it.
+
+  ## Why normalize rather than legalize
+
+  1. **Demand collapsed.** Above.
+  2. **Value is absent.** Only two semantic consumers of edge types exist:
+     `is_blocking()` at orient.rs:126,146 (`Derives | Implements`) and drift
+     propagation at drift.rs:255 (`Derives | Contradicts`, `_ => continue`).
+     Both whitelist, so a legalized `relates_to` was fixture-tested
+     byte-identical to `supports` for ready-work, dependents and drift. It
+     fails kos's own admission test
+     (`elem-machine-consumption-earns-formal-structure`), and roadmap Part 4
+     already cut upfront edge-ontology work with Issue 17 pre-registered to
+     PRUNE toward derives/contradicts/supersedes, not grow.
+  3. **Cost is measured.** `SCHEMA_VERSION` is hardcoded "0.3" at init.rs:8
+     with no negotiation. Under the deployed binary, **normalize restores 50
+     of 50 hidden nodes; legalize restores 7 of 50**, leaving 43 invisible
+     until every fleet binary upgrades. This inverts the intuition the gate
+     was built on.
+  4. **Loss is controllable.** Per-edge review with an `[orig: <type>]`
+     retention note yields zero irrecoverable in-file loss.
+
+  ## The residue, sized by reading all 15 leaves-open edges
+
+  | class | n | carried by |
+  |---|---|---|
+  | inverse direction (question to element) | 4 | derives / discovered_from |
+  | element genuinely partially resolved the question | 1 | partially_resolves |
+  | conditional invalidation, not exclusion | 1 | see below |
+  | genuine scope exclusion | 9 | nothing in the eight |
+
+  Two of the 15 are reciprocal pairs, so 13 distinct relations.
+
+  The 9 are weaker than the count suggests, for three measured reasons:
+
+  - **Every one already states the assertion in prose in the same node.**
+    `elem-mvp-scope-single-lan`: "The MVP scope itself is bedrock; the next
+    scope is open." `elem-timeslice-framing`: "The model is bedrock; the tick
+    rates are tuning parameters." `elem-sync-architecture`: "deferred
+    post-MVP." This retires the strongest argument for legalizing, which was
+    a Grudin re-extraction debt (structure paid for once, discarded, re-parsed
+    later from free text). No such debt exists: the prose was never removed,
+    because the prose is what the extractor was reading when it invented the
+    type.
+  - **They carry two different meanings.** Commitment granularity (5, all
+    switchboard session-049, near-identical phrasing) and temporal deferral
+    (4). One type would conflate them on day one.
+  - **Concentration.** 5 of 9 are one author in one session.
+
+  Landing: `out_of_scope` node field with named target ids. The Node struct
+  carries no `deny_unknown_fields`, so a field costs zero version skew where
+  an edge drops the whole node in every pre-loader binary. Migration is
+  mechanical because the prose to populate it already sits in each node.
+
+  ## Sub-question (c) was the real defect, and it shipped
+
+  One unrecognized edge type failed the whole-document parse. Every read path
+  then skipped the entire NODE and warned only on stderr, so `orient --json`,
+  the path agents read, emitted a clean, well-formed, confidently incomplete
+  graph with no signal anything was missing. That is
+  `elem-ai-improvisation-past-broken-refs` firing exactly as described.
+
+  Shipped in kos PR #89 (`3495ed1`), released `alpha-20260809-030901-3495ed1`:
+  `EdgeType` deserialization is infallible, unknown types become
+  `Unknown(raw)` preserving the author's string verbatim, never blocking and
+  never propagating; `validate` FAILS on unknown and names the offending value
+  plus the legal vocabulary; `orient` gained an in-band degradation signal on
+  both human and `--json` paths; `doctor`'s affirmative false green
+  (`parse_errors` hardcoded 0) fixed.
+
+  Measured: **117 own-graph nodes visible across the 7 affected repos where 67
+  were before, exactly the 50 predicted**, with no node file edited. Fleet
+  validate flipped from "50 parse errors, 0 failed" to "0 parse errors, 50
+  failed": nothing hidden, everything wrong named.
+
+  ## Premises found false during the adjudication
+
+  Recorded because the rate matters more than any single item. Four were
+  claims I carried in, three were in the graph's own artifacts.
+
+  - MEASURED: "any graph written with a new edge type is dropped wholesale by
+    every older binary" is FALSE. Tested against a real 2026-04-05 binary:
+    per-NODE, 17 of 83.
+  - MEASURED: the illegal-value distribution counted failing NODES, not edge
+    instances. True per-edge: related 50, leaves-open 15, others 12; 77
+    illegal edges inside 50 nodes.
+  - MEASURED: marvel 57d058f's loss was overstated. Exactly 2 edges dropped
+    outright, both restored as prose 7 minutes later in 05f4f3a; durable
+    in-file loss is original type strings on 18 retyped edges.
+  - MEASURED: "only two consumers" is right for SEMANTIC consumers but
+    graph.rs:78-79 also renders types as Display labels (cosmetic).
+  - `brief-lenient-edge-loading`: its claim that `kos validate` exits 0 on
+    parse errors is FALSE; it exits 1. Mechanism demonstrated: piping validate
+    through `tail` masks the exit code.
+  - `question-edge-vocabulary-gap`: the convergence claim, above.
+  - The adjudication brief cited orc charter "F22"; no such section exists.
+
+  ## Not confirmed, recorded as a data point only
+
+  `elem-multi-display-mute-sync` to `question-per-monitor-state` is not a
+  scope exclusion. Its content says "when per-monitor state becomes
+  authoritative, the absolute-set rationale dissolves": a decision declaring
+  what would invalidate it, i.e. `conditional_on` plus a falsifier, both
+  already specified for schema v0.4.
+
+  This is ONE field specimen, not demand evidence. A lexical sweep for
+  conditional/invalidation language returned 23 nodes, but most are incidental
+  prose; genuinely edge-shaped cases are roughly 4 to 6, and at least one
+  (`grv-git-as-sufficient-substrate`) is ALREADY carried today by
+  `contradicts` with `signal: evolution`. The existing `signal:` axis may
+  cover the semantic without a new type.
+
+  ## The generalizable result
+
+  Every apparent demand for a new edge type dissolved into an existing type,
+  an existing axis, or a node field. The schema is less short of vocabulary
+  than it looks, and shorter of places to put things that are not
+  relationships. This predicts the outcome Issue 17 already pre-registered:
+  the vocabulary prunes rather than grows.
+
+  Second, for process: a fleet-wide bulk campaign propagates its schema errors
+  to every repo it touches in one pass. Six repos went nonconformant in one
+  afternoon because nothing validated before the first write. Validate before
+  the first repo, not after the last.
+
+  ## Dissent, preserved
+
+  1. **`leaves_open` as a ninth type** (the one non-majority vote). It is the
+     only invented type with demonstrated post-repair operator demand: marvel
+     restored the dropped exclusions as prose within 7 minutes and filed a
+     ticket wanting them back as edges. Vindicated if Issue 24's reopener
+     machinery ships consuming edge-shaped exclusions rather than node-level
+     triggers, or if the field convention measurably fails in practice.
+  2. **Restructure the eight** into a closed machine signal (blocking,
+     propagates) plus an open free-text label. Position refuted, diagnosis
+     explicitly salvaged by its refuter. Vindicated if Issue 17 measures
+     traversal value below authoring cost AND the read path lands in the
+     activation/PPR mold that consumes open-vocabulary relation text.
+  3. **One fenced weak type anyway**, on doctrine: every mature KOS standard
+     admits exactly one (skos:related, rdfs:seeAlso, RT), and
+     `val-incremental-formalization` forbids forced up-front classification.
+     Vindicated by recurrence of invented weak vocabulary AFTER the lenient
+     loader and the validate gate have both propagated.
+
+  ## Open
+
+  - Whether `relates_to` ever earns admission. Defers to Issue 17 and to what
+    shape the read path actually consumes. Not settleable now.
+  - Whether `out_of_scope` stays a field or becomes an edge. Needs Issue 24 to
+    name its consumer.
+  - Whether orient's local-only blocker resolution is a defect or intended
+    semantics. Cross-graph and probe targets are permanent blockers; marvel
+    has two live specimens from its own repair.
+  - How to verify fleet binary propagation before any future vocabulary
+    change. No binary inventory exists; a stale 2026-04-16 build was found in
+    kos/target/release during this work and briefly contaminated measurements.
+  - Whether the roughly-80-percent lossless-normalization figure holds across
+    all 51 related/relates edges. It rests on a 15-edge read sample.
+edges:
+  - target: question-edge-vocabulary-gap
+    type: partially_resolves
+    note: "answers (b), (c) and (d); (a) defers to Issue 17"
+  - target: elem-ai-improvisation-past-broken-refs
+    type: instantiates
+    note: "the silent whole-node drop is this element's pattern in kos's own loader"
+  - target: elem-machine-consumption-earns-formal-structure
+    type: supports
+    note: "the admission test both candidate types failed"
+  - target: val-incremental-formalization
+    type: supports
+    note: "dissent 3 rests on it; the ruling defers rather than overrides it"
+provenance:
+  created_by: agent
+  session: "aae-orc session 2026-08-08/09 (fleet kos compliance sweep)"
+  created_at: "2026-08-09"
+finding:
+  probe: brief-lenient-edge-loading
+  result: |
+    Eight edge types stand. Scope exclusion lands as the out_of_scope node
+    field. Lenient loading shipped and released; 50 nodes restored fleet-wide
+    with no node file edited.

--- a/_kos/nodes/frontier/question-edge-vocabulary-gap.yaml
+++ b/_kos/nodes/frontier/question-edge-vocabulary-gap.yaml
@@ -3,6 +3,48 @@ type: question
 confidence: frontier
 title: "Does schema v0.3's edge vocabulary need a weak-association type and a scope-exclusion type?"
 content: |
+  ## ADJUDICATED 2026-08-09 — see finding-044
+
+  (b), (c) and (d) are answered. (a) defers to Issue 17. The body below is
+  the question AS ORIGINALLY POSED, kept verbatim; its central evidentiary
+  claim is false and is corrected under CORRECTION further down.
+
+  RULING: **the eight edge types stand. No new edge types.**
+  - (a) `relates_to`: NO. Roughly 80% of the `related` instances are
+    misfiled derives/supports/discovered_from; the residue is carried by
+    note prose. Revisit only via Issue 17, after a consumer of weak-
+    association semantics exists.
+  - (b) `leaves_open`: NOT an edge. The scope-exclusion semantic lands as
+    an `out_of_scope` node field with named target ids (bd aae-orc-gq1c).
+    Promotion condition, recorded here because bd aae-orc-dboj is CLOSED
+    and no longer functions as the anchor this node's tail assumes: it
+    becomes an edge type if and when a consumer ships that reads it
+    edge-shaped, direction pinned element-to-question.
+  - (c) SHIPPED. Lenient loading, kos PR #89 / `3495ed1`, released
+    alpha-20260809-030901-3495ed1. Unknown types load as `Unknown(raw)`
+    preserving the author's string; validate FAILS and names the value
+    plus the legal vocabulary. 50 nodes restored fleet-wide, no node file
+    edited.
+  - (d) Migration needs no loader and no binary change: normalization
+    restores 50/50 under the already-deployed binary. Rules in bd
+    aae-orc-ow62.
+
+  CORRECTION to the SIGNAL block below: "convergent, multiple repos,
+  independent authors" is FALSE. 48 of the 50 offending nodes were last
+  modified on or before 2026-05-13 and 39 on that single day, which was
+  one fleet-wide charter-extraction campaign run in a single session
+  across six repos. The repos are multiple; the authors and session are
+  not. (A later pass found at least three sessions in total, tmux-cmc
+  2026-04-02 and sidestep 2026-05-03; the convergence claim fails either
+  way.) The counts below also conflate nodes with edge instances: true
+  per-edge figures are related 50, leaves-open 15, others 12, i.e. 77
+  illegal edges inside 50 nodes.
+
+  Dissent is preserved in finding-044 and must not be dissolved by this
+  ruling; one of four voters held for `leaves_open` as a ninth type.
+
+  ---
+
   Field evidence (fleet inventory, 2026-07-17): authors across the
   aae-orc fleet convergently invent edge types the schema lacks, and
   the strict loader then drops the ENTIRE node — marvel ran two months
@@ -61,12 +103,16 @@ content: |
   BLOCKED on this question — normalizing before adjudication would
   repeat marvel's lossy mapping fleet-wide.
 edges:
+  - target: finding-044-edge-vocabulary-adjudicated
+    type: partially_resolves
+    note: "the adjudication: (b)(c)(d) answered, (a) deferred to Issue 17"
   - target: val-incremental-formalization
     type: derives
     note: "the weak-edge demand is this guardrail applied to edge authoring"
   - target: val-typed-traversable
     type: contradicts
-    note: "capture-time weak edges vs must-be-typed — the tension this question adjudicates"
+    signal: error
+    note: "OVERSTATED, see finding-044. That value is cited by exactly two nodes (elem-correspondence-layer, elem-storage-model), both session-001, both via the legacy v0.1 depends_on field, and both about the spec-to-code correspondence layer rather than intra-graph edge typing. This contradicts edge, added here 2026-07-17, is the only artifact treating it as a general typing mandate. Retained rather than deleted because the tension it names is real at capture time, but it should not be read as bedrock forbidding a weak type."
   - target: elem-formality-considered-harmful
     type: derives
   - target: elem-ai-improvisation-past-broken-refs

--- a/_kos/probes/brief-lenient-edge-loading.yaml
+++ b/_kos/probes/brief-lenient-edge-loading.yaml
@@ -80,3 +80,26 @@ brief:
       node file edits
   timebox: "one focused session (~150-250 lines incl. tests) + release"
   predicted_confidence: bedrock
+  status: complete
+  outcome: |
+    Shipped 2026-08-09 in kos PR #89 (`3495ed1`), released as
+    alpha-20260809-030901-3495ed1 and verified from the brew-installed
+    binary. See finding-044.
+
+    Every success signal met. 117 own-graph nodes visible across the 7
+    affected repos where 67 were before, exactly the 50 predicted, with no
+    node file edited. Fleet validate flipped from "50 parse errors, 0
+    failed" to "0 parse errors, 50 failed": nothing hidden, everything
+    wrong named. 5 new tests, 20 passing.
+
+    One premise in this brief was FALSE and is corrected in finding-044:
+    approach step 3 claimed `kos validate` exits 0 on parse errors, making
+    any CI gate a no-op. It exits 1, scoped and merged. The mechanism that
+    produced the wrong reading is worth keeping: piping validate through
+    `tail` masks the exit code. Only the "unknown edge type = FAIL" half of
+    step 3 was outstanding, and it shipped.
+
+    Scope note: the CI gate this brief anticipated (bd aae-orc-bs28) was
+    subsequently ruled ADVISORY rather than blocking, to avoid a chilling
+    effect on authors who genuinely need new vocabulary while Issue 17 is
+    still open.


### PR DESCRIPTION
The edge-vocabulary question has gated a fleet-wide repair sweep since 2026-07-17, and its central piece of evidence turns out to be false. This harvest records the adjudication, corrects the question node, and closes the probe that shipped last night.

## Ruling

**The eight edge types stand. No new edge types.**

Fifteen-agent adjudication: four research lenses, four argued positions, four adversarial cross-examinations each casting an independent verdict, two live simulations, recorded vote. Three of four voters for normalize-eight at high confidence, and it was the only position to survive its own cross-examination.

- **(a) `relates_to`: no.** Roughly 80% of `related` instances are misfiled `derives`/`supports`/`discovered_from`; the residue is carried by note prose. Defers to Issue 17.
- **(b) `leaves_open`: not an edge.** Lands as an `out_of_scope` node field. The `Node` struct carries no `deny_unknown_fields`, so a field costs zero version skew where an edge drops the whole node in every pre-loader binary.
- **(c) shipped** in #89.
- **(d)** normalization restores 50/50 nodes under the already-deployed binary, so migration waits on nothing.

## The premise that failed

The question treated the invented types as convergent independent invention across eight repos, and that claim is what made legalization look justified.

Measured: 48 of the 50 offending nodes were last modified on or before 2026-05-13, and 39 on that single day. That day was one fleet-wide charter-extraction campaign run in a single session across six repos, every commit of the form `harvest(kos): extract ... from charter`. The repos are multiple; the authors and the session are not.

Its counts also conflated nodes with edge instances. True per-edge: `related` 50, `leaves-open` 15, others 12, so 77 illegal edges inside 50 nodes.

## The residue, sized by reading all 15

Of 15 `leaves-open` edges: 4 are inverse-direction (`derives`/`discovered_from`), 1 is genuinely `partially_resolves`, 1 is conditional invalidation rather than exclusion, and **9 are genuine scope exclusions no existing type carries**.

All 9 already state the assertion in prose in the same node, which retires the strongest argument for legalizing: there is no re-extraction debt, because the prose was never removed. It is what the extractor was reading when it invented the type.

## On the `val-typed-traversable` contradiction

Annotated rather than deleted. That value is cited by exactly two nodes, both session-001, both via the legacy `depends_on` field, and both about the spec-to-code correspondence layer rather than intra-graph edge typing. This node is the only artifact that read it as a general typing mandate, via a `contradicts` edge it added to itself in July.

## Dissent

Preserved verbatim in finding-044 with vindication conditions, not dissolved: `leaves_open` as a ninth type (the one non-majority vote), restructuring the eight into a machine signal plus an open label, and admitting one fenced weak type on doctrine.

## Cost of merge

Documentation and graph only. No code, no schema change. `kos validate` clean: 83 nodes, 78 passed, 5 warnings, 0 failed, 0 parse errors.

Refs: aae-orc-znzh, aae-orc-ow62, aae-orc-gq1c, aae-orc-1sd8, aae-orc-bs28