### PR TITLE
read path first steps: substrate report, proposal, frontier questions, telemetry slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # kos drift snapshots (local state, not committed)
 .drift-snapshot.json
 
+# kos read telemetry (per-session logs under any graph, not committed)
+.telemetry/
+
 # IDE
 .idea/
 .vscode/

--- a/_kos/nodes/frontier/question-kos-ask-retrieval-value.yaml
+++ b/_kos/nodes/frontier/question-kos-ask-retrieval-value.yaml
@@ -1,0 +1,125 @@
+id: question-kos-ask-retrieval-value
+type: question
+confidence: frontier
+title: "Does `kos ask` beat grep and unfiltered orient on real session questions, and does it get used?"
+content: |
+  `kos ask <question>` (bd `aae-orc-jajn3`, Phase 0) is a scoped, ranked
+  retrieval verb over the graph: lexical matching plus graph proximity
+  as the interim substrate, with the verb as the durable contract and
+  the substrate free to change underneath it (flyloft eventually, per
+  bd `aae-orc-di23`). The stated decision criterion is that it improve
+  ranking, freshness, and provenance over `grep` against real session
+  questions.
+
+  That criterion contains two claims which can come apart, and the
+  order between them is the point of this node.
+
+  **The quality claim.** Ranked, graph-aware retrieval returns better
+  answers than substring search over `_kos/` or an unfiltered
+  `kos orient` dump the reader must triage themselves.
+
+  **The adoption claim.** Sessions actually reach for it mid-work.
+
+  **Pre-registered ordering: adoption dominates.** If sessions keep
+  reaching for grep after the verb exists, the verb failed, regardless
+  of how well it scores on any benchmark. A retrieval tool that wins
+  offline and goes unused is a benchmark artifact, and
+  `elem-who-pays-survival-predictor` says so directly: what survives is
+  determined by who pays and who benefits, not by measured quality.
+  This ordering is recorded here before the verb ships so that a good
+  benchmark result cannot be substituted for the outcome that matters
+  (`val-locked-predictions`).
+
+  **How adoption is measured.** Consultation-class reads in the read
+  telemetry (`question-read-telemetry-decision-value`, bd
+  `aae-orc-2qlx0`). This is why the instrument sequences before the
+  verb: without it, adoption is an anecdote, and the ten-session
+  circulation clock has no honest start point.
+
+  **Success signal (testable).** Over the ten sessions following the
+  verb shipping, BOTH of:
+  (a) `kos ask` is invoked in at least half of the sessions that
+      consult the graph at all; and
+  (b) at least one session records a question answered through a hit
+      the lexical match set did not contain, meaning graph proximity
+      did work that grep could not have done.
+  Both halves are required. Adoption without (b) means the verb
+  replaced grep by ergonomics and habit rather than by retrieval merit,
+  which is a real but much smaller result and should be recorded as
+  that rather than as a win.
+
+  **Kill condition (graveyard).** After the same ten sessions, either
+  (a) fewer than a quarter of graph-consulting sessions invoke it, or
+  (b) no recorded case where proximity ranking beat plain lexical
+  search. On either, the verb moves to graveyard with the finding that
+  the retrieval gap is not lexical-plus-proximity shaped. The next
+  attempt then belongs to flyloft's substrate work, not to a second
+  implementation inside kos.
+
+  **Scope guard.** The verb must not grow into flyloft-inside-kos.
+  Embeddings, rerankers, and a vector store are out of scope for
+  Phase 0 by construction; the failure mode being guarded is winning
+  the quality claim by absorbing another project's roadmap.
+
+  **Trust companions.** A ranked answer that presents an untested
+  finding as authoritative is worse than grep, which at least hands the
+  reader the raw file and its context. bd `aae-orc-37hm` (tested and
+  untested findings are indistinguishable) and `aae-orc-qao2` (who pays
+  to trust) carry that half; this node depends on their state without
+  resolving them.
+
+  Sub-questions:
+  1. **What is the benchmark corpus, and when is it collected?** Real
+     session questions, captured before the verb ships. Collected after,
+     the corpus is selected by whoever knows what the verb can do, which
+     is the same defect `val-locked-predictions` guards against.
+  2. **Is grep the honest control?** The realistic alternative may be
+     unfiltered `kos orient` plus the reader's own scan, which is a
+     stronger baseline than substring search and the one the verb has
+     to beat in practice.
+  3. **Does graph proximity contribute measurable lift?** If lexical
+     matching carries the whole result, the graph is decorative in the
+     ranking and success signal (b) is unreachable by construction.
+  4. **Can the verb rank a bedrock node above a superseded one without
+     a separate freshness model?** The freshness and provenance parts of
+     the criterion may need schema support (supersedes edges, confidence
+     tiers) that the ranking does not currently read.
+  5. **If adoption is high but only from agents and never from humans,
+     is that success?** It satisfies the letter of the signal. Whether
+     it satisfies the intent depends on whether the operator is meant
+     to be a user of the read path or only its beneficiary.
+
+  Cross-graph parents (no cross-graph edge primitive exists yet; see
+  aae-orc finding-133):
+  - aae-orc `_kos/nodes/frontier/question-active-knowledge-surfacing.yaml`
+    (charter F19), the PUSH half of the same problem.
+  - aae-orc `_kos/ideas/kos-read-path-gap.md`.
+
+  Proposal: `docs/proposals/read-path-first-steps.md`.
+  bd: `aae-orc-jajn3` (this verb), `aae-orc-2qlx0` (the measurement it
+  is judged by), `aae-orc-37hm` and `aae-orc-qao2` (trust side),
+  `aae-orc-di23` (which surface it lands on first).
+edges:
+  - target: question-read-telemetry-decision-value
+    type: derives
+    note: "Adoption is measured in consultation-class reads; the instrument must exist first or the success signal is anecdote."
+  - target: val-retrieval-before-capture
+    type: derives
+    note: "This verb is the retrieval value the rule requires before further author-side capture ships."
+  - target: elem-who-pays-survival-predictor
+    type: derives
+    note: "Grounds the pre-registered ordering: adoption dominates benchmark quality."
+  - target: val-locked-predictions
+    type: derives
+    note: "The adoption-dominates ordering and the benchmark corpus timing are fixed before the verb ships."
+  - target: elem-grudin-asymmetric-cost-benefit
+    type: derives
+    note: "The verb is the retrieval benefit whose absence the asymmetry predicts will kill the system."
+provenance:
+  created_by: agent
+  session: "2026-08-16 read-path-first-steps"
+  created_at: "2026-08-16"
+  derived_from:
+    - "docs/proposals/read-path-first-steps.md"
+    - "aae-orc vision.md Gap 0 fix order (adopted 2026-08-01)"
+    - "aae-orc _kos/ideas/kos-read-path-gap.md direction 2"

--- a/_kos/nodes/frontier/question-read-surface-sequencing.yaml
+++ b/_kos/nodes/frontier/question-read-surface-sequencing.yaml
@@ -1,0 +1,123 @@
+id: question-read-surface-sequencing
+type: question
+confidence: frontier
+title: "Does verb-first-then-MCP hold, or does read benefit only arrive inside the agent task loop?"
+content: |
+  The adopted sequencing (bd `aae-orc-di23`, and Track B of
+  `aae-orc-b0kp` round 3) is one query engine behind three faces over
+  time: the `kos ask` CLI verb now, a kos-side read-only MCP Phase 0
+  next (after the M0 schema repair, because serving a graph with
+  undeclared edge types means serving falsehoods with a clean API), and
+  flyloft federation later when flyloft is real. The reasoning was
+  soonest-surface plus federation-not-foreclosed, and it is recorded as
+  a decision rather than a finding because no evidence has been
+  gathered for it.
+
+  The counter-position is worth stating at full strength, because it
+  changes what a low adoption number means. A CLI verb requires the
+  agent to decide to shell out to a tool it was not already holding. An
+  MCP tool sits inside the task loop, in the same list the model is
+  already choosing from. If read benefit lands mostly there, then
+  measuring `kos ask` adoption from the CLI measures the wrong surface,
+  and a weak result reads as "retrieval is unwanted" when it actually
+  means "the surface is one hop too far away".
+  `elem-machine-consumption-earns-formal-structure` cuts in this
+  direction: structure earns its keep at the moment a machine consumes
+  it, and the MCP face is where the machine is.
+
+  This matters operationally, not just philosophically. The kill
+  condition in `question-kos-ask-retrieval-value` is adoption-weighted.
+  If the sequencing claim is wrong and unexamined, that node can
+  execute a graveyard verdict on a verb that was fine and a surface
+  that was misplaced.
+
+  **Evidence.** Consultation-read share by surface. The telemetry
+  already records a verb field; when MCP Phase 0 lands its reads are
+  tagged as a distinct surface. Two comparisons follow: per-session
+  consultation-read counts in the CLI-only era against the MCP era, and
+  within the MCP era, the CLI-versus-MCP split for sessions that use
+  both.
+
+  **Success signal for the adopted sequencing (testable).** CLI-era
+  consultation reads reach the adoption floor stated in
+  `question-kos-ask-retrieval-value` (invocation in at least half of
+  graph-consulting sessions) without MCP existing. Verb-first survives;
+  MCP Phase 0 proceeds as a convenience face rather than as the fix for
+  a missed surface.
+
+  **Alternative confirmed (falsifies the sequencing, not the read
+  path).** CLI-era consultation reads sit below that floor, and MCP-era
+  per-session consultation reads rise by a factor of two or more over
+  the same query engine. Then verb-first is falsified as a sequencing
+  claim: the `kos ask` graveyard verdict is vacated, the ADR recording
+  the sequencing is superseded rather than the verb, and future read
+  features target the task loop first.
+
+  **Kill condition for this question (graveyard).** If MCP Phase 0 is
+  still unbuilt once the M0 repair has landed and two harvest review
+  rounds have passed, this question has no evidence path and moves to
+  graveyard as unfalsifiable in practice. The adopted sequencing then
+  stands by default, and the record says explicitly that it stands
+  unmeasured rather than confirmed.
+
+  **Standing constraint.** Whatever the verdict, it changes which face
+  ships next, never how many engines exist. Two permanent servers over
+  the same graph is the ruled-out failure the ADR records; a result
+  that argues for MCP-first argues for reordering faces, not for a
+  second implementation.
+
+  Sub-questions:
+  1. **Can telemetry attribute reads to a surface reliably?** An MCP
+     server is a separate process with its own session identity. If
+     session IDs do not line up, the CLI-versus-MCP split inside one
+     session is not computable and only the era comparison remains.
+  2. **Is a factor of two the right threshold, and is between-era the
+     right comparison?** Within-session comparison is stronger evidence
+     and weaker on sample size. The threshold above is a first cut, set
+     before data exist so that it cannot be tuned to the result.
+  3. **Does the M0 repair break the comparison?** An MCP era serving a
+     repaired graph is not comparing like with like against a CLI era
+     that served an unrepaired one. Some of any measured lift belongs
+     to the repair.
+  4. **What if flyloft becomes real before MCP Phase 0?** The question
+     either re-targets to flyloft's surface or dissolves, depending on
+     whether flyloft fronts the same engine or replaces it.
+  5. **Is there a cheap intermediate that tests the hypothesis without
+     building the server?** Putting `kos ask` in an agent's default
+     reach through a rule or skill approximates in-loop availability at
+     a fraction of the cost, and would separate "wrong surface" from
+     "wrong verb" before Phase 0 is committed.
+
+  Cross-graph parents (no cross-graph edge primitive exists yet; see
+  aae-orc finding-133):
+  - aae-orc `_kos/nodes/frontier/question-active-knowledge-surfacing.yaml`
+    (charter F19). Surface placement is where the PULL and PUSH halves
+    meet: an in-loop tool is closer to surfacing than a verb the agent
+    must remember to call.
+  - aae-orc `_kos/ideas/kos-read-path-gap.md`.
+
+  Proposal: `docs/proposals/read-path-first-steps.md`.
+  bd: `aae-orc-di23` (single-surface decision and its ADR),
+  `aae-orc-b0kp` (Track B ordering), `aae-orc-jajn3` (the verb whose
+  verdict this can vacate), `aae-orc-2qlx0` (the evidence source).
+edges:
+  - target: question-kos-ask-retrieval-value
+    type: derives
+    note: "That node's kill condition is adoption-weighted; this question decides whether a low number indicts the verb or its surface."
+  - target: question-read-telemetry-decision-value
+    type: derives
+    note: "Consultation-read share by surface is the only evidence path available for this question."
+  - target: elem-machine-consumption-earns-formal-structure
+    type: derives
+    note: "Grounds the MCP-first counter-position: benefit arrives at the moment the machine reads it."
+  - target: val-locked-predictions
+    type: derives
+    note: "The threshold and comparison shape are fixed before either era has data."
+provenance:
+  created_by: agent
+  session: "2026-08-16 read-path-first-steps"
+  created_at: "2026-08-16"
+  derived_from:
+    - "docs/proposals/read-path-first-steps.md"
+    - "bd aae-orc-di23 (single MCP surface decision)"
+    - "bd aae-orc-b0kp round-3 Track B ordering"

--- a/_kos/nodes/frontier/question-read-telemetry-decision-value.yaml
+++ b/_kos/nodes/frontier/question-read-telemetry-decision-value.yaml
@@ -1,0 +1,117 @@
+id: question-read-telemetry-decision-value
+type: question
+confidence: frontier
+title: "Does read telemetry change a later read-feature decision, or does the instrument go unread like the graph it measures?"
+content: |
+  kos records nothing about which nodes are consulted. The telemetry
+  collection slice (bd `aae-orc-2qlx0`, roadmap v3 Issue 20) logs the
+  node IDs served by each `kos orient` invocation to a per-session
+  append-only JSONL file, classified at log time as CONSULTATION
+  (targeted or filtered orient, later `kos ask`) or BULK-SERVE
+  (unfiltered orient, which marks essentially the whole graph as read
+  by construction). The aggregator that would turn those lines into an
+  answer is a separate, unbuilt seam (bd `aae-orc-kx8f`).
+
+  The stated justification is that every later read-feature decision
+  (ranking weights for `kos ask`, cold-node retirement, circulation as
+  promotion evidence, flyloft's eventual role) should rest on measured
+  circulation rather than intuition. That justification is a
+  prediction, not a fact, and it is exposed to the exact failure it
+  was built to detect: an instrument nobody consults is the same
+  defect as a graph nobody reads, one layer up. `val-retrieval-before-capture`
+  governs author-side capture cost; no rule yet governs a machine-paid
+  instrument whose output no decision consumes.
+
+  This node holds that uncertainty open. The claim under test is not
+  "can we collect read events" (that is an engineering task with a
+  known answer) but "does having collected them change what someone
+  decides".
+
+  **Success signal (testable).** Within five sessions of the aggregator
+  existing, at least one named read-feature decision cites specific
+  telemetry output as evidence, in a finding, an ADR, or ticket notes
+  that name the decision, the number the telemetry produced, and the
+  alternative the number ruled out. A citation that would read the
+  same with the number deleted does not count.
+
+  **Kill condition (graveyard).** Two consecutive harvest review rounds
+  in which no decision consulted the telemetry and nobody can name a
+  pending decision that would. On the second, this question moves to
+  graveyard: collection stops, the log format is recorded as an
+  artifact so a later attempt does not redesign it, and the aggregator
+  is not built. The recorded lesson would be that measure-before-build
+  is cheaper to say than to consume.
+
+  **Standing constraint.** Per `val-diagnostic-never-gate`, nothing may
+  gate on these numbers. A success signal that hardens into a required
+  check falsifies itself; the citation must come from a human or agent
+  choosing to look, not from CI failing.
+
+  **Pre-registration (amended before any data collection, per
+  `val-locked-predictions`).** The slice-1 deliverable is orient-shape
+  statistics, not the circulation hypothesis. The ten-session
+  "at least 40% of nodes are never read after creation" clock starts
+  when `kos ask` lands and counts consultation reads only. Recording
+  this before collection is what prevents the hypothesis from being
+  re-fitted to whatever the first data show.
+
+  Sub-questions:
+  1. **What counts as a decision citing the telemetry?** The success
+     signal is only testable if citation-as-evidence is separable from
+     citation-as-decoration. The proposed test above (delete the number,
+     does the sentence change?) is a first cut and may not survive a
+     real case.
+  2. **Is five sessions the right window, and measured from what?**
+     From the collector shipping, or from the aggregator existing? The
+     signal above says the aggregator, on the reasoning that raw JSONL
+     is not a consultable instrument. That choice is arguable.
+  3. **Does the consultation/bulk split survive real usage?** If
+     unfiltered `kos orient` is the overwhelming majority of
+     invocations, the consultation stream may be too thin to support
+     any decision, and the split will have measured the tool's shape
+     rather than the graph's circulation.
+  4. **Who reads it?** If the only consumer is the agent that wrote the
+     line in the same session, the Grudin asymmetry has reappeared
+     inside the instrument (see `elem-grudin-asymmetric-cost-benefit`)
+     and the instrument is self-serving rather than institutional.
+  5. **What if the telemetry is never consulted but `kos ask` succeeds
+     anyway?** That outcome would falsify measure-before-build as
+     applied here without falsifying the read path. It is the most
+     informative failure available and should be recorded as such
+     rather than quietly absorbed.
+
+  Cross-graph parents (no cross-graph edge primitive exists yet; see
+  aae-orc finding-133):
+  - aae-orc `_kos/nodes/frontier/question-active-knowledge-surfacing.yaml`
+    (charter F19). That question is the PUSH half (surfacing what you
+    did not know to ask for); this one sits under the PULL half.
+  - aae-orc `_kos/ideas/kos-read-path-gap.md`, the idea this
+    crystallized from.
+
+  Proposal: `docs/proposals/read-path-first-steps.md`.
+  bd: `aae-orc-2qlx0` (collection slice), `aae-orc-kx8f` (aggregator
+  seam), `aae-orc-b0kp` (Track B sequencing this sits inside).
+edges:
+  - target: val-retrieval-before-capture
+    type: derives
+    note: "Telemetry is the measurement that would demonstrate retrieval value; the rule is what makes the measurement load-bearing."
+  - target: elem-grudin-asymmetric-cost-benefit
+    type: derives
+    note: "The asymmetry this instrument exists to detect, and the one it may itself fall to."
+  - target: val-diagnostic-never-gate
+    type: derives
+    note: "Standing constraint: these numbers inform decisions and never block them."
+  - target: val-locked-predictions
+    type: derives
+    note: "The pre-registration above is fixed before collection and immutable post-harvest."
+  - target: question-act-r-decay-as-confidence-model
+    type: supports
+    note: "Retrieval counts are the frequency input ACT-R decay needs; that question is downstream of this instrument earning its keep."
+provenance:
+  created_by: agent
+  session: "2026-08-16 read-path-first-steps"
+  created_at: "2026-08-16"
+  derived_from:
+    - "docs/proposals/read-path-first-steps.md"
+    - "docs/kos-roadmap-v3.md Issue 20"
+    - "aae-orc vision.md Gap 0 (adopted 2026-08-01)"

--- a/docs/kos-substrate-alternatives.md
+++ b/docs/kos-substrate-alternatives.md
@@ -1,0 +1,346 @@
+# KOS Substrate Alternatives — Options More Ideal Than TerminusDB
+
+> Follow-up to the TerminusDB suitability assessment. That report scored
+> TerminusDB best-in-class on the five substrate properties but failing on
+> three axes: no in-process embedding (Docker/server daemon), single-steward
+> health (DFRNT), and WOQL/Prolog skill asymmetry for LLM agents. "More
+> ideal" therefore means: fixes those three axes while conceding as little
+> as possible of P1–P5 and the git-semantics fit. All health claims verified
+> July 2026 against primary sources.
+
+---
+
+## Verdict
+
+**Two candidates beat TerminusDB outright for KOS; two more are
+probe-watch; the rest are disqualified.**
+
+1. **Dolt** — fixes all three failure axes at once (best-in-class health,
+   SQL skill symmetry, single static brew-installable binary — no Docker,
+   no JVM) while *keeping* real git semantics: true branch/merge/diff,
+   cell-level conflict detection, `AS OF` time travel, cherry-pick as
+   selective harvest. And it is already inside KOS's fence: Embedded Dolt
+   became the default backend of Beads in April 2026 [@dolthub2026beads] —
+   the task tracker KOS's platform already runs.
+2. **SQLite + append-only fact log** (Datomic-shaped, built thin) — the
+   only candidate that is fully in-process from Rust with bedrock health;
+   you build branching/asof/harvest in application space, which at KOS's
+   scale (hundreds of nodes) is a bounded, ownable amount of code.
+3. *Probe-watch:* **DoltLite** (embedded SQLite-compatible Dolt, March
+   2026 — architecturally the ideal endpoint, but four months old and
+   experimental) and **Turso** (Rust SQLite rewrite — MVCC multi-writer,
+   built-in MCP mode, but branching is cloud-only and the engine is beta).
+
+---
+
+## What changed since the TerminusDB report
+
+Four landscape facts, all 2025–2026, all verified:
+
+**Kuzu is dead.** Archived without warning October 10, 2025; repo
+read-only; docs pulled; "Kuzu is working on something new"
+[@biggo2025kuzu; @register2025kuzu]. Community forks ("bighorn,"
+"Ladybug") exist but inherit an on-disk format that was never stabilized
+[@biggo2025kuzu]. Health-disqualified — a sharper cautionary tale than
+TerminusDB itself.
+
+**Cozo is dormant.** Last release v0.7 (November 2023); no releases since;
+the database-of-databases entry accessed June 2026 still lists v0.7 as
+current [@dbdb2026cozo]. The single-author risk flagged in the prior
+report materialized. Demoted from probe candidate to design reference
+(its Datalog time-travel model remains instructive).
+
+**Dolt went from strong to dominant.** Dolt 2.0 shipped May 11, 2026
+(storage-stable, adaptive storage, version-controlled vector indexes)
+[@dolthub2026dolt2; @infoq2026dolt2]; Doltgres 1.0 lands August 6, 2026
+[@dolthub2026doltgres]; DoltHub now explicitly markets Dolt as "the
+database for AI agents": *every agent gets its own branch, writes are
+isolated until you review and merge, rollback is surgical* — which is
+KOS's P5 + human-pawl + harvest model restated as a product pitch
+[@dolthub2026agents]. A Dolt MCP server exists and was extended to
+Doltgres in July 2026 [@dolthub2026blog].
+
+**An embedded Dolt lane opened.** DoltLite launched March 25, 2026: a
+free, open-source, drop-in SQLite replacement (C library, WASM target)
+with Dolt version control as SQL functions — `dolt_add`, `dolt_commit`,
+`dolt_log` in-process [@dolthub2026doltlite]. Separately, Embedded Dolt
+(the Go library form) became Beads' default backend, "restoring the
+simple single-player experience without an external server"
+[@dolthub2026beads]. The embedding objection that disqualified
+TerminusDB is being solved in the Dolt ecosystem from two directions.
+
+---
+
+## Tier 1, candidate 1: Dolt
+
+**P1 — first-class edges: PARTIAL→FIT.** Edges as rows in an
+`edges(from, to, type, provenance…)` table: independently queryable,
+diffable, versioned per-cell, carrying their own columns. Not
+graph-native typing — schema discipline replaces it — but every edge has
+commit-granularity history, which YAML-in-git never gave.
+
+**P2 — preserved reasoning chains: PARTIAL→FIT via modeling.** Dolt
+versions rows, not datoms. Model the graph as an append-only EAV fact
+table (never UPDATE, only INSERT with op add/retract) and Dolt's commit
+graph supplies transaction context on top: `dolt_log`, `dolt_diff`,
+`dolt_history_facts` reconstruct any derivation. History is structurally
+the primary record — Prolly-tree content addressing with structural
+sharing [@infoq2026dolt2].
+
+**P3 — projections on demand: FIT.** SQL views and queries; charter,
+subgraph bundles, drift reports are all `SELECT`s. Best possible LLM
+agent fluency — SQL is the one query language with saturated training
+data.
+
+**P4 — asof/time-travel: FIT.** `AS OF <commit|timestamp>` queries are
+native; `kos asof` for blinded retrodiction maps directly
+[@dbdb2026dolt].
+
+**P5 — concurrent multi-agent: FIT, and productized.** Branch-per-agent
+isolation with cell-level conflict detection at merge is DoltHub's own
+recommended agent pattern [@dolthub2026agents; @dolthub2026conflicts].
+
+**Git-semantics/harvest: FIT — the best available.** True branch, diff,
+merge, rebase; `dolt_cherry_pick()` and cross-branch
+`INSERT INTO main SELECT … AS OF branch` are *literal selective harvest*,
+the operation KOS defined and no other candidate ships.
+
+**Operational:** single static Go binary, Homebrew-installable, fully
+offline, no Docker, no JVM. From Rust: sidecar `dolt sql-server` over
+MySQL wire (`mysql_async`) or shelling to the CLI; or the Go embedded
+library if any KOS component tolerates Go (Beads proves the pattern in
+this exact ecosystem [@dolthub2026beads]). Sidecar-penalized but the
+penalty is one supervised child process of a boring binary — not a
+container.
+
+**Health:** exceptional. Funded company, eight-year track record,
+storage-format stability promise since 1.0, weekly releases
+[@dolthub2026dolt2; @dolthub2026doltgres]. Apache 2.0.
+
+**MDE checklist:** lock-in LOW (MySQL-dialect SQL, `dolt dump`, open
+format); round-trip MODERATE (migrate, don't mirror, same as
+TerminusDB); skill asymmetry LOW — the decisive win.
+
+**Build cost on top:** EAV schema + edge tables + a thin `kos` shim
+mapping cycle verbs to Dolt verbs (probe branch = `dolt branch`,
+harvest = cherry-pick/select-into, promote = merge to main). Weeks, not
+months; no query engine, no history engine, no conflict engine to write.
+
+## Tier 1, candidate 2: SQLite + append-only fact log
+
+The boring build: `rusqlite` in-process; `facts(e, a, v, tx, op)`
+append-only; `tx(id, parent, branch, author, ts)` giving a transaction
+DAG; current state as a view; `asof` as a tx-filter; branches as DAG
+metadata; harvest as fact-copy with new tx. Mozilla's abandoned Mentat
+is the direct design reference for Datomic-on-SQLite in Rust.
+
+**P1 FIT** (edges are facts). **P2 FIT** (this *is* the datom model).
+**P3 FIT** (SQL). **P4 FIT** (tx-filtered views). **P5 PARTIAL** —
+SQLite is single-writer; WAL + short transactions is fine at KOS scale,
+and branch-per-agent contention is nil, but it is a ceiling.
+**Git-semantics PARTIAL** — you implement branch/diff/harvest yourself
+(diff = set difference on fact tables — genuinely small).
+
+**Operational: the only full FIT** — in-process from the existing Rust
+CLI, zero sidecar, brew ships one binary, bedrock health, SQL symmetry.
+**Cost:** the versioning layer is yours to build and own (~the size of
+kos's existing `charter.rs`+`drift.rs` work, at KOS scale) and yours to
+maintain forever. Lock-in: none. This is the Grudin-clean option — the
+machine that pays is code you own.
+
+## Tier 2 — probe-watch
+
+**DoltLite** [@dolthub2026doltlite]: architecturally the ideal terminal
+state — SQLite embedding *plus* Dolt version control *plus* SQL. But:
+four months old, ~42 stars, author-supported in a personal repo, and by
+its creator's own framing "first and foremost an experiment" in fully
+AI-generated code whose DoltHub support will be reassessed on usage
+[@dolthub2026doltlitesupport]. Smoke-test it (same SQL surface as Probe
+A below, ~30 minutes); do not depend on it.
+
+**Turso (Rust rewrite of SQLite)**: in-process, MIT, ~23k stars, 253
+contributors, beta; MVCC `BEGIN CONCURRENT` lifts the single-writer
+ceiling; CDC and a built-in MCP server mode [@explainx2026turso;
+@dbdb2026turso]. Branching is metadata-instant — *in Turso Cloud's
+object-store architecture*, not the local embedded engine
+[@turso2026what]. Reads as the succession path for the SQLite lane once
+it stabilizes: adopt candidate 2's schema on SQLite today, inherit MVCC
+by swapping the engine later.
+
+## Disqualified
+
+| Candidate | One-line reason |
+| --- | --- |
+| Kuzu (+ forks) | Archived 2025-10-10; unstable on-disk format; forks unproven [@biggo2025kuzu; @register2025kuzu] |
+| CozoDB | Dormant since v0.7 (2023-11); single author; niche DSL [@dbdb2026cozo] |
+| XTDB v2 / Datomic / Datalevin | JVM; no branching (XTDB/Datomic); disqualified on ops |
+| SurrealDB | BSL license + embedded/versioning maturity unproven (per prior report; unre-verified) |
+| Oxigraph | No versioning; SPARQL asymmetry; app-layer history = candidate 2 with worse skill fit |
+| Automerge/CRDT class | Automatic merge is doctrinally opposed to harvest-not-merge and the human pawl |
+| Irmin | Conceptually perfect mergeable store; OCaml — impractical from Rust |
+| lakeFS/DVC/Oxen | File-granularity versioning; wrong layer — no graph query |
+
+## M4 probe design (revised)
+
+**Probe A — Dolt.** ThreeDoors-104 as EAV facts + edge table; sidecar
+`dolt sql-server` from the Rust CLI via `mysql_async`. Test: (i) full
+derivation-chain reconstruction for one finding via `dolt_history`/
+`dolt_diff`; (ii) `AS OF` historical query for retrodiction; (iii) probe
+branch → divergent finding → **cherry-pick harvest** to main without
+merge; (iv) two concurrent writers on separate branches. Optional
+30-minute DoltLite smoke test of (i)–(iii) on the identical SQL.
+Pre-registered `predicted_confidence`: 0.75.
+
+**Probe B — SQLite fact log.** Same four operations implemented on
+`rusqlite` within a one-session build timebox. Pre-registered
+`predicted_confidence`: 0.6 that all four land inside the timebox.
+
+**Decision rule.** If B completes all four within the timebox and the
+diff/harvest code stays under an agreed size budget → choose B
+(in-process wins; Turso as engine succession). Otherwise → choose A
+(sidecar cost buys mature branch/merge/asof machinery). If A wins and
+DoltLite's smoke test passes clean → open a watch item to migrate the
+sidecar to DoltLite when it exits experimental status. Either outcome
+supersedes the TerminusDB probe recommendation: **TerminusDB drops to
+tier 3** — its remaining unique asset (graph-native typed schema with
+versioned migrations) is not worth the daemon + Prolog + steward risk
+against these two.
+
+## Gained / lost vs TerminusDB
+
+**Gained:** health (Dolt/SQLite are the two healthiest options in the
+entire field), SQL skill symmetry (maximal LLM fluency vs minimal),
+no-Docker local-first ops, an ecosystem precedent already inside the
+platform (Beads on Embedded Dolt), and — Dolt only — selective harvest
+as a shipped primitive. **Lost:** graph-native typed schema and
+schema-migration-as-commits (replaced by SQL DDL discipline plus kos's
+own validate layer — which already exists), and RDF/JSON-LD standards
+alignment (never a KOS requirement). **P1–P5 impact of the loss: none
+that modeling discipline doesn't cover;** the losses are conveniences,
+not properties.
+
+## Risk register (top 2)
+
+| Risk | Candidate | Severity | Note |
+| --- | --- | --- | --- |
+| Sidecar lifecycle management | Dolt | Medium | Child-process supervision in the CLI; failure modes are boring and testable |
+| EAV modeling discipline | Dolt | Medium | Nothing stops an UPDATE; enforce append-only via triggers/validate gate |
+| Go dependency drift | Dolt | Low | Single static binary pinned by brew formula |
+| Build-and-own versioning layer | SQLite | Medium-High | Weeks of code, forever yours; scope-creep is the real hazard |
+| Single-writer ceiling | SQLite | Low-Med at KOS scale | Mitigated by WAL + branch metadata; Turso succession path |
+| DoltLite immaturity | (watch) | High if depended on | Experimental, personal-repo, AI-generated codebase |
+
+---
+
+## Bibliography
+
+```bibtex
+@misc{biggo2025kuzu,
+  author = {{BigGo News}},
+  title = {KuzuDB, the Promising Embedded Graph Database, is Suddenly Archived},
+  year = {2025},
+  howpublished = {\url{https://biggo.com/news/202510130126_KuzuDB-embedded-graph-database-archived}},
+  note = {Archived 2025-10-10; on-disk format never stabilized}
+}
+@misc{register2025kuzu,
+  author = {{The Register}},
+  title = {KuzuDB graph database abandoned, community mulls options},
+  year = {2025},
+  howpublished = {\url{https://www.theregister.com/2025/10/14/kuzudb_abandoned/}}
+}
+@misc{dbdb2026cozo,
+  author = {{Database of Databases}},
+  title = {CozoDB},
+  year = {2026},
+  howpublished = {\url{https://dbdb.io/db/cozodb}},
+  note = {Accessed 2026-06; latest documented release v0.7, 2023-11-21}
+}
+@misc{dolthub2026dolt2,
+  author = {Sehn, Tim},
+  title = {Dolt 2.0},
+  year = {2026},
+  howpublished = {\url{https://www.dolthub.com/blog/2026-05-11-dolt-2-dot-0/}}
+}
+@misc{infoq2026dolt2,
+  author = {Losio, Renato},
+  title = {Version Controlled SQL Database Dolt Releases 2.0 with Automatic Storage Cleanup and Compression},
+  year = {2026},
+  howpublished = {\url{https://www.infoq.com/news/2026/07/dolt-version-control/}}
+}
+@misc{dolthub2026doltgres,
+  author = {Fulghum, Jason},
+  title = {Doltgres 1.0 Coming August 6th},
+  year = {2026},
+  howpublished = {\url{https://www.dolthub.com/blog/2026-06-26-doltgres-1-0-coming-this-fall/}}
+}
+@misc{dolthub2026agents,
+  author = {Leng, James},
+  title = {Dolt, The Database for AI Agents},
+  year = {2026},
+  howpublished = {\url{https://www.dolthub.com/blog/2026-05-18-database-for-ai-video/}},
+  note = {Branch-per-agent isolation; review-then-merge; surgical rollback}
+}
+@misc{dolthub2026conflicts,
+  author = {Sehn, Tim},
+  title = {How Users Manage Merge Conflicts in Dolt},
+  year = {2026},
+  howpublished = {\url{https://www.dolthub.com/blog/?tags=dolt}},
+  note = {2026-05-27 entry; cell-level conflict management}
+}
+@misc{dolthub2026doltlite,
+  author = {Sehn, Tim},
+  title = {Introducing DoltLite},
+  year = {2026},
+  howpublished = {\url{https://www.dolthub.com/blog/2026-03-25-doltlite/}},
+  note = {SQLite-compatible embedded engine with Dolt version control as SQL functions}
+}
+@misc{dolthub2026doltlitesupport,
+  author = {Sehn, Tim},
+  title = {DoltHub Adopts DoltLite},
+  year = {2026},
+  howpublished = {\url{https://www.dolthub.com/blog/2026-04-14-dolthub-adopts-doltlite/}},
+  note = {``first and foremost an experiment''; support reassessed on usage}
+}
+@misc{dolthub2026beads,
+  author = {Brown, Dustin},
+  title = {Restoring Beads Classic},
+  year = {2026},
+  howpublished = {\url{https://www.dolthub.com/blog/2026-04-02-restoring-beads-classic/}},
+  note = {Embedded Dolt as Beads' default backend, no external server}
+}
+@misc{dolthub2026blog,
+  author = {{DoltHub}},
+  title = {DoltHub Blog index},
+  year = {2026},
+  howpublished = {\url{https://www.dolthub.com/blog/}},
+  note = {Dolt MCP server extended to Doltgres, July 2026}
+}
+@misc{dbdb2026dolt,
+  author = {{Database of Databases}},
+  title = {Dolt},
+  year = {2026},
+  howpublished = {\url{https://dbdb.io/db/dolt}},
+  note = {Cell-based conflict detection; embedded and server modes}
+}
+@misc{dbdb2026turso,
+  author = {{Database of Databases}},
+  title = {Turso},
+  year = {2026},
+  howpublished = {\url{https://dbdb.io/db/turso}},
+  note = {Limbo rewrite history; copy-on-write branching; MVCC}
+}
+@misc{explainx2026turso,
+  author = {{ExplainX}},
+  title = {Turso Database: SQLite Rewritten in Rust with MVCC, Async I/O and Vector Search},
+  year = {2026},
+  howpublished = {\url{https://www.explainx.ai/blog/turso-database-sqlite-rust-rewrite-guide-2026}},
+  note = {Beta; 20k+ stars; 253 contributors; MCP server mode}
+}
+@misc{turso2026what,
+  author = {{Turso}},
+  title = {What is Turso?},
+  year = {2026},
+  howpublished = {\url{https://turso.tech/what-is-turso}},
+  note = {Metadata-only branching in cloud object-store architecture}
+}
+```

--- a/docs/proposals/read-path-first-steps.md
+++ b/docs/proposals/read-path-first-steps.md
@@ -1,0 +1,374 @@
+# Proposal: kos Read Path, First Steps
+
+Status: proposed (2026-08-16). A probe, not a commitment to outcomes.
+Scope: kos read features. Audience: a future kos session executing from
+this document.
+
+## The goal
+
+Turn kos from a warehouse into a library. Make Query a working verb of
+the operating loop.
+
+kos has a working write path and almost no read path. What exists today
+is `kos orient` (a bulk per-cwd dump with substring filtering, `--json`,
+and `--ready`) plus hygiene reads (validate, drift, doctor, reflect,
+graph, compact, charter render). There is no `kos ask`, no read
+telemetry, no MCP surface, and no `kos status`. Nothing anywhere records
+whether a node has ever been consulted.
+
+Three of the project's own documents diagnose this with one voice:
+
+- `vision.md` (adopted 2026-08-01) names the operating loop as Write /
+  Query / Generate / Judge, calls Query "Gap 0, the weakest verb,"
+  marks kos "USABLE; read path missing," and gives the fix order
+  cheapest first: read-telemetry loglines, then `kos ask` (lexical plus
+  graph-proximity interim, flyloft as eventual substrate), then
+  "findable or it isn't harvested" as a harvest gate. Gap 0 gates the
+  operating loop.
+- `_kos/ideas/kos-read-path-gap.md` (2026-07-15): "A knowledge system
+  with writes and no reads is a warehouse, not a library." This is the
+  PULL half; F19 active surfacing is the PUSH half.
+- `kos/docs/kos-roadmap-v3.md` and `v3_1.md` (2026-07-04) promote the
+  MR (Retrieval-First) milestone above capture discipline, because
+  every prior knowledge system died of the Grudin asymmetry: capture
+  cost and retrieval benefit fall on different people. Standing rules
+  carried forward here: no new author-side capture before retrieval
+  value is demonstrated; metrics stay diagnostic and never gate;
+  automate proposing, never judging.
+
+## Five proof obligations
+
+In order.
+
+1. **Measure reads before building anything heavier.** Grudin
+   discipline applied to ourselves. Telemetry records which node IDs
+   are actually served, so every later read-feature decision (ranking,
+   `kos ask` scoring, promotion evidence, cold-node retirement,
+   flyloft's eventual role) rests on measured circulation rather than
+   intuition. Ten-session baseline; pre-registered hypothesis "at least
+   40 percent of nodes are never read post-creation." Ticket:
+   `aae-orc-2qlx0` (collection slice), with `aae-orc-kx8f` as the
+   aggregator-side seam.
+2. **Ship a query verb agents and humans use mid-session.** `kos ask
+   <question>`: scoped, ranked retrieval, lexical plus graph-proximity
+   as the interim substrate. The verb is the contract; the substrate
+   swaps later. It must not grow into flyloft-inside-kos. Ticket:
+   `aae-orc-jajn3`.
+3. **Keep the read surface honest.** Do not serve a corrupted graph
+   (M0 schema repair before any server, per `aae-orc-b0kp`); do not
+   serve untested findings as if tested (`aae-orc-37hm`); do not let
+   machine-paid features smuggle in operator rituals (the `aae-orc-b0kp`
+   cross-track rule); do not let confirm-or-override decay into
+   rubber-stamping (`aae-orc-qao2`).
+4. **Converge the surfaces, do not multiply them.** One query engine
+   behind three faces over time: CLI verb now, kos-side read-only MCP
+   Phase 0 next, flyloft federation later. Recorded as ADR-009;
+   `aae-orc-di23` is resolved by sequencing rather than by choosing a
+   single permanent home.
+5. **Repair the record so the plan is traceable.** Gap 0 lives in the
+   adopted vision but was absent from the adopted roadmap spine;
+   `kos ask` and read telemetry had no bd tickets at all; "R1" named
+   three different things; and the substrate report cited as settled in
+   `aae-orc-1od3` existed but was chat-produced and never committed.
+   That last item is a structural harvest gap in the collaboration
+   itself: a planning conversation is a probe surface whose findings do
+   not exist for repo sessions until they are committed, and repo
+   sessions had started citing ghosts.
+
+## The plan, three waves
+
+### Wave 1: records reconciliation (orc repo and kos repo docs, one sitting, PRs)
+
+Green-lit by operator review 2026-08-16 with three amendments, all
+folded in: amend the telemetry pre-registration before any data
+collection; commit the chat-produced substrate report and file a
+finding on the chat-as-probe-surface harvest gap; adopt an R-prefix
+convention.
+
+- Commit the chat-produced documents so cross-session references
+  resolve. `kos/docs/kos-substrate-alternatives.md` carries the
+  substrate report verbatim (verdict: Dolt and a SQLite fact log beat
+  TerminusDB; DoltLite and Turso are probe-watch; Kuzu is dead; Cozo is
+  dormant; revised M4 Probe A/B design with pre-registered confidences
+  0.75 and 0.6 and a decision rule; TerminusDB drops to tier 3).
+  Confirm `kos-roadmap-v3`, `v3_1`, and `kos-use-assessment` are
+  committed. Then update `aae-orc-1od3`: the report is located and
+  committed; the remaining work is naming the two "five properties"
+  lists distinctly (finding-036's what-files-cannot-provide versus the
+  report's what-a-versioned-store-must-provide) and tracing `isie`'s
+  design-field claims either to props or to an "asserted, unverified"
+  tag.
+- File the chat-as-probe-surface finding in the orc `_kos/findings/`.
+  No new rule this wave; a pointer from the tooling-friction-adjacent
+  rules only if it earns one.
+- File the two missing read-path tickets: `aae-orc-jajn3` (`kos ask`
+  Phase 0) and `aae-orc-2qlx0` (read-telemetry collection slice). Both
+  flat, per the bd-hierarchy rule; no invented parents.
+- Fix the record discontinuities. Add the Gap 0 read-path item to
+  `docs/roadmap.md` Track K as K7 (summary and pointer only, per
+  charter-light-touch). Disambiguate the three "R1"s with one
+  clarifying line, without rewriting history documents. Note the
+  crystallization in `_kos/ideas/kos-read-path-gap.md`, pointing at the
+  new tickets.
+- Adjudicate `aae-orc-uuob` (sequencing conflict). It likely dissolves:
+  the recorded criterion is that `aae-orc-b0kp` stands unless the
+  ten-session telemetry clock is genuinely on retrodiction's critical
+  path, and with collection starting now and the circulation clock
+  re-pinned to `kos ask`, it probably is not. Check
+  `kos-roadmap-v3.md` Issue 25 for whether retrodiction's baseline
+  consumes telemetry, write the adjudication into the ticket notes, and
+  close if it dissolves.
+- Draft ADR-009 for `aae-orc-di23`: one query engine, three faces over
+  time. Record why two permanent servers is the ruled-out failure and
+  why a kos-side Phase 0 does not foreclose federation.
+- Write this proposal and cross-link it from every new ticket.
+- Create the three kos frontier question nodes (see Epistemic status
+  below).
+
+Not worked in this wave: `aae-orc-1y3g`, `aae-orc-37hm`, and
+`aae-orc-qao2` are open items with their own criteria and are only
+cross-referenced here. `aae-orc-1y3g` gates the SCIP ingest, not this
+wave.
+
+### Wave 2: telemetry collection slice (kos repo)
+
+Ticket: `aae-orc-2qlx0`.
+
+A minimal read-telemetry module in kos: fail-open, logging the node IDs
+served by `kos orient`, per-session append-only JSONL, on by default,
+machine-paid, never a gate.
+
+Spec sources: `kos-roadmap-v3.md` Issue 20 (`_kos/.telemetry/reads.jsonl`,
+node IDs served, ten-session clock) and `kos-nine-improvements.md`
+(tuple of node_id, command, session, timestamp; diagnostic, never a
+gate). The existing `--log` precedent in `orient.rs` logs counts only,
+is opt-in, and is machine-global. The gap this fills is IDs,
+graph-scoped, on by default.
+
+Shape:
+
+- New `src/telemetry.rs` with `ReadEvent { verb, target, node_ids,
+  finding_ids }`, `record_reads(graph_dir, &event)`, and `session_id()`.
+- Location `<graph>/_kos/.telemetry/reads-<session>.jsonl`: the
+  document's directory, `aae-orc-b0kp`'s per-session multiplicity.
+  Graph-scoped rather than under `~/.local/share`, because aggregation
+  is per-graph and machine-global storage reintroduces multi-writer
+  contention. Add `.telemetry/` to kos's `.gitignore`, matching the
+  `.drift-snapshot.json` precedent.
+- Session ID from `KOS_SESSION` if set, else `<pid>-<unix-start-secs>`.
+  Worst case that degenerates to one file per invocation, which is
+  still contention-free; the aggregator globs.
+- One JSONL line per invocation with ID arrays: `ts`, `session`, `verb`,
+  `target`, `read_class`, `json_output`, `node_ids`, `finding_ids`. One
+  atomic write preserves co-service context, and the per-node tuple is
+  derivable at aggregation time.
+- Instrument `run()` in `orient.rs` once, after the `Orientation` struct
+  is populated, since both printers render everything in it (so
+  "served" means "present in `Orientation`"). Instrument `run_ready()`
+  as verb `orient-ready`. Do not instrument doctor (a health check, not
+  consumption) or reflect (it serves just-edited nodes, which would
+  contaminate the never-read-after-creation hypothesis). Slice 1 is
+  orient only.
+- Reads are `Orientation.{bedrock_nodes, frontier_questions,
+  graveyard_nodes}` plus finding IDs. Charter items, probes, ideas, and
+  `rd_*` are excluded: they are not graph nodes, and the hypothesis is
+  about nodes.
+- Fail-open at the call site, mirroring the existing warning pattern in
+  `orient.rs`. Telemetry can never fail orient, and nothing reads it in
+  any check path.
+- On by default with a `KOS_NO_TELEMETRY` opt-out checked at the call
+  site, keeping the function pure and parameterized for tests. IDs
+  only, no content; gitignored; local.
+
+Tests, unit-level in `telemetry.rs` with a tempfile dev-dependency:
+appends valid JSONL; appends rather than truncates; distinct sessions
+produce distinct files; errors on an unwritable directory (proving
+fail-open is caller-side); opt-out skips the write.
+
+Ship via kos's normal flow (main-branch repo, PR), commit vocabulary
+`probe(kos):` or `feat:` per its conventions. Close `aae-orc-2qlx0` on
+merge.
+
+### Wave 3: cheap code-graph measurements (parallel, machine-paid)
+
+Run under their existing tickets once `aae-orc-aj3c` (the arc seed)
+lands, or alongside it. Neither gates Waves 1 or 2; both inform whether
+the SCIP ingest is ever worth building.
+
+- `aae-orc-5lbu`: install Serena, measure it as the live-LSP baseline
+  against real session workloads (CG-R2; registered prediction 0.65
+  insufficient).
+- `aae-orc-msqx`: measure `rust-analyzer scip` and `scip-go` time and
+  memory on the full workspace (CG-Q1). The claim that CG-R1 cannot
+  land on YAML-in-git is asserted, not measured.
+
+### Explicitly deferred
+
+Recorded, not started:
+
+- `kos ask` implementation itself. The next wave after telemetry lands;
+  `aae-orc-jajn3` carries the design pointer.
+- MCP Phase 0, after M0 schema repair per `aae-orc-b0kp` round-3 item 2.
+- The telemetry aggregator and its consumers, gated on the writer model;
+  `aae-orc-kx8f` is the seam.
+- The SCIP-to-kos ingest (five blockers), reopener triggers,
+  retrodiction, and the F19 predictor push half.
+
+## Sequencing inheritance
+
+The standing sequencing decision is `aae-orc-b0kp` (party consensus,
+round-3 amended). It splits work into two tracks:
+
+- **Track A**, operator-facing, serial, gated by the operator's habit
+  budget.
+- **Track B**, the read side, machine-paid, parallel. Nothing in Track B
+  may spend Track A's budget; that cross-track rule is what keeps a
+  machine-paid feature from smuggling in an operator ritual.
+
+Track B order, inherited by this proposal unchanged:
+
+1. `validate` as CLI plus CI.
+2. M0 schema repair before any MCP surface. An MCP server over a
+   corrupted graph serves lies with a nice API, and finding-060
+   measured roughly 24 percent undeclared-type edges under green
+   validation.
+3. Telemetry collection starts now, as per-session append-only files.
+   That is `aae-orc-2qlx0`, Wave 2 above.
+4. MCP read-only Phase 0.
+5. Reopener triggers.
+6. Retrodiction.
+
+Three decisions taken in the 2026-08-16 planning session sit on top of
+that order. Scope: reconcile the record and start the cheapest
+machine-paid build. Read surface: `kos ask` as a CLI verb first, with
+the kos-side MCP Phase 0 later wrapping the same query engine and
+flyloft fronting it eventually, which satisfies `aae-orc-di23`'s
+criterion of soonest surface without foreclosing federation. Code-graph
+arc: fold in only the two cheap measurements (`aae-orc-5lbu`,
+`aae-orc-msqx`); the SCIP ingest stays gated.
+
+## Pre-registration amendment
+
+Written before any data collection, and carried in the body of
+`aae-orc-2qlx0`. It exists to prevent the HARKing-adjacent re-scope
+that the Kerr guard (roadmap Issue 10) was put in place for.
+
+1. **Reads are classified at log time**, not at analysis time, into two
+   classes. CONSULTATION covers targeted or filtered orient and the
+   future `kos ask`. BULK-SERVE covers unfiltered orient, which marks
+   essentially the whole graph as read by construction. The class is
+   written into the `read_class` field on each event.
+2. **The slice-1 deliverable is orient-shape statistics**, not the
+   circulation hypothesis. Slice 1 tells us how orient is actually
+   invoked and in what proportion the two classes occur. It does not
+   test whether nodes go unread.
+3. **The ten-session circulation clock starts when `kos ask` lands**,
+   and it counts consultation reads only. The hypothesis under that
+   clock is "at least 40 percent of nodes are never read
+   post-creation." Starting the clock earlier, or counting bulk serves
+   toward it, would answer a different question with the same number
+   and call it the same result.
+
+## Epistemic status
+
+This proposal is a probe, not a commitment to outcomes. Two layers of
+uncertainty are held open structurally rather than rhetorically.
+
+**Benefit uncertainty.** Telemetry, `kos ask`, and the chosen sequencing
+may not deliver the intended value. The plausible failures are a
+measured-but-unconsulted instrument, an unused verb, and a surface in
+the wrong place.
+
+**Approach uncertainty.** The read-path-first approach itself
+(Grudin-ordered, verb before server, measure before build) may be wrong.
+The pre-registered hypotheses and the `aae-orc-b0kp` / `aae-orc-uuob`
+adjudication trail are what let us find that out rather than argue it.
+
+Three kos frontier nodes carry that uncertainty, each with a testable
+success signal and a kill condition, so the graveyard can collect
+honestly. Their subject is kos, so they live in kos's graph
+(`kos/_kos/nodes/frontier/`, schema v0.3). Each cross-links to this
+proposal, to its tickets, and to the orc-level parents
+(question-active-knowledge-surfacing, F19, and the
+`kos-read-path-gap.md` idea).
+
+- **`question-read-telemetry-decision-value`**. Does measuring
+  circulation actually change a later read-feature decision (ranking,
+  retirement, promotion evidence), or does the instrument go unread
+  like the graph it measures? Success: a named decision cites the
+  telemetry within N sessions of the aggregator existing. Kill: two
+  consecutive review rounds where nobody consulted it.
+- **`question-kos-ask-retrieval-value`**. Does `kos ask` beat grep and
+  unfiltered orient on real session questions, against the ranking,
+  freshness, and provenance criterion, and does it get used?
+  Consultation reads in the telemetry are the usage measurement.
+  Pre-registered: if sessions keep reaching for grep after the verb
+  exists, the verb failed regardless of benchmark quality. The kill
+  condition is explicit in the node.
+- **`question-read-surface-sequencing`**. Does verb-first-then-MCP
+  hold, or does the benefit only arrive inside the agent task loop
+  (the MCP-first argument)? Evidence: consultation-read share from the
+  CLI versus, later, from MCP.
+
+The orc-level chat-as-probe-surface finding stays at the orc. If that
+failure recurs, it graduates to its own question node.
+
+## Verification
+
+- **Wave 1**: PRs merged on orc main and kos main; this proposal
+  carries real ticket IDs; the frontier nodes pass `kos validate`;
+  `bd show` resolves the new tickets; `aae-orc-uuob` notes carry the
+  adjudication; `docs/roadmap.md` Track K names the read path; ADR-009
+  appears in `decisions/index.md`.
+- **Wave 2**: it builds; `kos orient kos` twice, then `ls
+  _kos/.telemetry/` shows `reads-<pid>-<ts>.jsonl`, and
+  `KOS_SESSION=test-a` produces `reads-test-a.jsonl`; `jq .node_ids`
+  over the file, diffed against orient's printed `[id]` lines, gives
+  matching sets; `time kos orient kos` before and after shows no
+  measurable slowdown; `git status` confirms `.telemetry/` is ignored;
+  tests green.
+- **Wave 3**: measurements recorded in `aae-orc-5lbu` and
+  `aae-orc-msqx` plus findings, per the arc's own criteria.
+
+Note for whoever runs Wave 2's verification: `command -v kos` resolves
+to the Homebrew binary. Built code has to be exercised with `cargo run
+--` from the kos checkout.
+
+## Conventions and pointers
+
+**R-prefix convention**, adopted 2026-08-16 and used in all new tickets
+and documents. "R1" previously named three different things, which is
+how the read-path item went missing from the roadmap spine without
+anyone noticing.
+
+| Prefix | Namespace |
+| --- | --- |
+| `UX-R*` | use-assessment items (`kos/docs/kos-use-assessment.md`) |
+| `CG-R*` | code-graph briefing items |
+| `Gap-0` | the vision.md read-path item |
+
+**Substrate**: `kos/docs/kos-substrate-alternatives.md`, committed
+alongside this proposal, is the report `aae-orc-1od3` refers to. It
+governs the eventual store choice under kos's read path, not the read
+path's first steps; nothing in Waves 1 through 3 depends on its
+outcome.
+
+**Ticket index for this proposal.**
+
+| Ticket | Task |
+| --- | --- |
+| `aae-orc-b0kp` | two-track sequencing decision (Track A / Track B) |
+| `aae-orc-uuob` | sequencing conflict adjudication (Wave 1) |
+| `aae-orc-di23` | single MCP surface decision, resolved by ADR-009 |
+| `aae-orc-1od3` | substrate report not in graph (Wave 1) |
+| `aae-orc-jajn3` | `kos ask` Phase 0 (deferred build; filed Wave 1) |
+| `aae-orc-2qlx0` | read-telemetry collection slice (Wave 2) |
+| `aae-orc-kx8f` | telemetry seam registration (aggregator side, deferred) |
+| `aae-orc-37hm` | untested findings indistinguishable (trust side) |
+| `aae-orc-qao2` | who pays to trust (trust side) |
+| `aae-orc-5lbu` | Serena baseline probe (Wave 3) |
+| `aae-orc-msqx` | scip cost probe (Wave 3) |
+| `aae-orc-aj3c` | code-graph arc seed (Wave 3 gate) |
+
+Labels on all new tickets, per convention: `aae-orc`, `kos`,
+`source:session`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod orient;
 pub mod process;
 pub mod reflect;
 pub mod seed;
+pub mod telemetry;
 pub mod updater;
 pub mod validate;
 pub mod workspace;

--- a/src/orient.rs
+++ b/src/orient.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use crate::bridge::RdFinding;
 use crate::error::{KosError, Result};
 use crate::model::{CharterItem, CharterSection, Confidence, Finding, Node, RdBrief};
+use crate::telemetry::{self, ReadClass, ReadEvent};
 use crate::workspace::{KOS_DIR, Workspace};
 
 /// Collected orientation data for a target repo.
@@ -61,7 +62,7 @@ pub fn run(workspace: &Workspace, target: &str, json: bool, log: bool, ready: bo
     let cwd = std::env::current_dir().map_err(KosError::Io)?;
 
     if ready {
-        return run_ready(workspace, &cwd, json);
+        return run_ready(workspace, &cwd, target, json);
     }
 
     let orientation = if workspace.is_standalone() {
@@ -83,7 +84,45 @@ pub fn run(workspace: &Workspace, target: &str, json: bool, log: bool, ready: bo
         }
     }
 
+    if telemetry::enabled() {
+        let (graph_dir, read_class) = telemetry_context(workspace, &cwd);
+        let event = ReadEvent {
+            verb: "orient",
+            target: &orientation.target,
+            read_class,
+            json_output: json,
+            // Both printers render everything in the Orientation, so what is
+            // present in it is what was served.
+            node_ids: orientation
+                .bedrock_nodes
+                .iter()
+                .chain(&orientation.frontier_questions)
+                .chain(&orientation.graveyard_nodes)
+                .map(|n| n.id.as_str())
+                .collect(),
+            finding_ids: orientation.findings.iter().map(|f| f.id.as_str()).collect(),
+        };
+        if let Err(e) = telemetry::record_reads(&graph_dir, &event) {
+            eprintln!("warning: could not write read telemetry: {e}");
+        }
+    }
+
     Ok(())
+}
+
+/// Where to log a read, and how to classify it.
+///
+/// Mirrors the branch `gather`/`gather_standalone` takes. Only the legacy
+/// fallback narrows nodes and findings by target; the graph paths load whole
+/// confidence tiers, which is a bulk serve however specific the target is.
+fn telemetry_context(workspace: &Workspace, cwd: &Path) -> (PathBuf, ReadClass) {
+    if workspace.is_standalone() {
+        (workspace.root.join(KOS_DIR), ReadClass::Bulk)
+    } else if let Some(graph) = workspace.nearest_graph(cwd) {
+        (graph.path.clone(), ReadClass::Bulk)
+    } else {
+        (workspace.node_root(), ReadClass::Consultation)
+    }
 }
 
 /// A frontier question classified as ready or blocked.
@@ -104,7 +143,7 @@ pub enum ReadyStatus {
 }
 
 /// Run the --ready computation: which frontier questions are actionable?
-fn run_ready(workspace: &Workspace, cwd: &Path, json: bool) -> Result<()> {
+fn run_ready(workspace: &Workspace, cwd: &Path, target: &str, json: bool) -> Result<()> {
     let nearest = workspace.nearest_graph(cwd);
     let graph_root = if let Some(graph) = nearest {
         graph.path.clone()
@@ -220,6 +259,23 @@ fn run_ready(workspace: &Workspace, cwd: &Path, json: bool) -> Result<()> {
         print_ready_jsonl(&ready_questions);
     } else {
         print_ready_human(&ready_questions);
+    }
+
+    if telemetry::enabled() {
+        let event = ReadEvent {
+            verb: "orient-ready",
+            target,
+            // --ready serves every frontier question by construction, so it
+            // cannot evidence consultation.
+            read_class: ReadClass::Bulk,
+            json_output: json,
+            node_ids: ready_questions.iter().map(|q| q.node.id.as_str()).collect(),
+            // Findings are loaded to resolve blockers, never served.
+            finding_ids: vec![],
+        };
+        if let Err(e) = telemetry::record_reads(&graph_root, &event) {
+            eprintln!("warning: could not write read telemetry: {e}");
+        }
     }
 
     Ok(())

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,263 @@
+#![forbid(unsafe_code)]
+
+//! Read telemetry: which graph IDs a read verb actually served.
+//!
+//! The graph records what was written and never recorded what was read, so
+//! every read-side decision (ranking, retirement, promotion evidence) rests
+//! on intuition. This module logs IDs only, per session, append-only, into
+//! the graph it describes. Nothing reads the output in any check path, and
+//! no code path may fail because a write here failed.
+//!
+//! See `docs/proposals/read-path-first-steps.md`.
+
+use std::ffi::OsStr;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Per-graph directory holding the session logs. Gitignored.
+const TELEMETRY_DIR: &str = ".telemetry";
+
+/// Any non-empty value disables collection (the `NO_COLOR` convention).
+const OPT_OUT_ENV: &str = "KOS_NO_TELEMETRY";
+
+/// Groups one agent session's reads into one file across invocations.
+const SESSION_ENV: &str = "KOS_SESSION";
+
+/// Session ids reach the filesystem, and filenames cap at 255 bytes on the
+/// platforms kos ships to.
+const SESSION_ID_MAX: usize = 64;
+
+/// How a read was served, decided at log time.
+///
+/// The circulation hypothesis (what share of nodes is never read after
+/// creation) can only be tested against consultation reads: an unfiltered
+/// orient marks essentially the whole graph as read by construction, so
+/// counting it would answer the question before asking it. Pre-registered
+/// before collection began.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadClass {
+    /// The served set was narrowed by what the caller asked for.
+    Consultation,
+    /// The served set is the graph (or a whole tier of it) by construction.
+    Bulk,
+}
+
+impl ReadClass {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Consultation => "consultation",
+            Self::Bulk => "bulk",
+        }
+    }
+}
+
+/// One invocation of a read verb: what it served, never what it contained.
+#[derive(Debug)]
+pub struct ReadEvent<'a> {
+    /// The verb as the user typed it (`orient`, `orient-ready`).
+    pub verb: &'a str,
+    /// Target repo the read was scoped to.
+    pub target: &'a str,
+    pub read_class: ReadClass,
+    /// Whether the caller asked for `--json` (agent reads vs human reads).
+    pub json_output: bool,
+    /// Graph node IDs served. Charter items, probes, ideas, and RD artifacts
+    /// are excluded: the hypothesis is about nodes.
+    pub node_ids: Vec<&'a str>,
+    /// Finding IDs served.
+    pub finding_ids: Vec<&'a str>,
+}
+
+/// Whether collection is on. On by default; checked at the call site.
+pub fn enabled() -> bool {
+    enabled_from(std::env::var_os(OPT_OUT_ENV).as_deref())
+}
+
+fn enabled_from(opt_out: Option<&OsStr>) -> bool {
+    !opt_out.is_some_and(|value| !value.is_empty())
+}
+
+/// This process's session id: `KOS_SESSION` when set, else `<pid>-<unix secs>`.
+///
+/// The derived form is fixed on first use so every read in one invocation
+/// lands in one file even if the process straddles a second boundary.
+pub fn session_id() -> String {
+    if let Some(explicit) = std::env::var_os(SESSION_ENV) {
+        let sanitized = sanitize(&explicit.to_string_lossy());
+        if !sanitized.is_empty() {
+            return sanitized;
+        }
+    }
+
+    static DERIVED: OnceLock<String> = OnceLock::new();
+    DERIVED
+        .get_or_init(|| {
+            let secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |since_epoch| since_epoch.as_secs());
+            format!("{}-{secs}", std::process::id())
+        })
+        .clone()
+}
+
+/// Reduce a session id to something safe to use as a filename. The value
+/// arrives from the environment, so a path separator or `..` would otherwise
+/// steer the log out of the graph.
+fn sanitize(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .take(SESSION_ID_MAX)
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    if cleaned.chars().all(|c| c == '.') {
+        String::new()
+    } else {
+        cleaned
+    }
+}
+
+fn log_path(graph_dir: &Path, session: &str) -> PathBuf {
+    graph_dir
+        .join(TELEMETRY_DIR)
+        .join(format!("reads-{session}.jsonl"))
+}
+
+/// Append one JSONL line describing `event` to this session's log.
+///
+/// Callers treat the error as advisory and keep going: telemetry is
+/// diagnostic and must never fail the verb it observes.
+pub fn record_reads(graph_dir: &Path, event: &ReadEvent<'_>) -> std::io::Result<()> {
+    record_reads_as(graph_dir, &session_id(), event)
+}
+
+/// The session id is a parameter here so tests can pin it. Setting the
+/// environment from a test is not available under edition 2024 without
+/// `unsafe`, which this crate forbids.
+fn record_reads_as(graph_dir: &Path, session: &str, event: &ReadEvent<'_>) -> std::io::Result<()> {
+    std::fs::create_dir_all(graph_dir.join(TELEMETRY_DIR))?;
+
+    let entry = serde_json::json!({
+        "ts": chrono::Utc::now().to_rfc3339(),
+        "session": session,
+        "verb": event.verb,
+        "target": event.target,
+        "read_class": event.read_class.as_str(),
+        "json_output": event.json_output,
+        "node_ids": event.node_ids,
+        "finding_ids": event.finding_ids,
+    });
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path(graph_dir, session))?;
+    writeln!(file, "{entry}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event() -> ReadEvent<'static> {
+        ReadEvent {
+            verb: "orient",
+            target: "kos",
+            read_class: ReadClass::Bulk,
+            json_output: false,
+            node_ids: vec!["question-read-telemetry-decision-value", "elem-node-schema"],
+            finding_ids: vec!["finding-044"],
+        }
+    }
+
+    fn read_lines(graph_dir: &Path, session: &str) -> Vec<String> {
+        std::fs::read_to_string(log_path(graph_dir, session))
+            .unwrap()
+            .lines()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn record_writes_valid_jsonl() {
+        let graph = tempfile::tempdir().unwrap();
+        record_reads_as(graph.path(), "sess-1", &sample_event()).unwrap();
+
+        let lines = read_lines(graph.path(), "sess-1");
+        assert_eq!(lines.len(), 1);
+
+        let parsed: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+        assert_eq!(parsed["session"], "sess-1");
+        assert_eq!(parsed["verb"], "orient");
+        assert_eq!(parsed["target"], "kos");
+        assert_eq!(parsed["read_class"], "bulk");
+        assert_eq!(parsed["json_output"], false);
+        assert_eq!(parsed["node_ids"].as_array().unwrap().len(), 2);
+        assert_eq!(parsed["finding_ids"][0], "finding-044");
+        assert!(parsed["ts"].as_str().unwrap().starts_with("20"));
+    }
+
+    #[test]
+    fn record_appends_rather_than_truncating() {
+        let graph = tempfile::tempdir().unwrap();
+        record_reads_as(graph.path(), "sess-1", &sample_event()).unwrap();
+        record_reads_as(graph.path(), "sess-1", &sample_event()).unwrap();
+
+        assert_eq!(read_lines(graph.path(), "sess-1").len(), 2);
+    }
+
+    #[test]
+    fn distinct_sessions_write_distinct_files() {
+        let graph = tempfile::tempdir().unwrap();
+        record_reads_as(graph.path(), "sess-1", &sample_event()).unwrap();
+        record_reads_as(graph.path(), "sess-2", &sample_event()).unwrap();
+
+        assert_eq!(read_lines(graph.path(), "sess-1").len(), 1);
+        assert_eq!(read_lines(graph.path(), "sess-2").len(), 1);
+    }
+
+    #[test]
+    fn record_surfaces_the_error_on_an_unwritable_dir() {
+        // A file where the graph directory should be: the caller, not this
+        // module, decides that a failure here is survivable.
+        let parent = tempfile::tempdir().unwrap();
+        let graph = parent.path().join("not-a-directory");
+        std::fs::write(&graph, "").unwrap();
+
+        assert!(record_reads_as(&graph, "sess-1", &sample_event()).is_err());
+    }
+
+    #[test]
+    fn opt_out_skips_the_write() {
+        let graph = tempfile::tempdir().unwrap();
+
+        // Mirrors the call site: the gate decides, the writer stays pure.
+        if enabled_from(Some(OsStr::new("1"))) {
+            record_reads_as(graph.path(), "sess-1", &sample_event()).unwrap();
+        }
+
+        assert!(!graph.path().join(TELEMETRY_DIR).exists());
+    }
+
+    #[test]
+    fn opt_out_is_off_when_unset_or_empty() {
+        assert!(enabled_from(None));
+        assert!(enabled_from(Some(OsStr::new(""))));
+        assert!(!enabled_from(Some(OsStr::new("0"))));
+    }
+
+    #[test]
+    fn session_id_stays_inside_the_telemetry_directory() {
+        assert_eq!(sanitize("../../etc/passwd"), "..-..-etc-passwd");
+        assert_eq!(sanitize(".."), "");
+        assert_eq!(sanitize("agent session 3"), "agent-session-3");
+        assert_eq!(sanitize(&"x".repeat(200)).len(), SESSION_ID_MAX);
+    }
+}


### PR DESCRIPTION
kos has a working write path and almost no read path; the adopted vision calls Query Gap 0, the weakest verb of the operating loop. This PR lands the first steps: the record repairs and the cheapest machine-paid build, so every later read-feature decision rests on measured circulation instead of intuition. Additive only; no existing verb changes behavior.

Contents:
- docs/kos-substrate-alternatives.md: the substrate report, previously chat-produced and uncommitted while repo sessions cited it (orc finding-136). Committed verbatim.
- docs/proposals/read-path-first-steps.md: the plan with its bd ticket registry (aae-orc-jajn3 kos ask, aae-orc-2qlx0 telemetry) and the pre-registration amendment.
- Three frontier question nodes, each with a pre-registered success signal and a kill condition. kos validate green (86 nodes, 0 failed).
- src/telemetry.rs plus orient instrumentation: fail-open, per-session JSONL of node and finding ids served, on by default with KOS_NO_TELEMETRY opt-out, ids only, gitignored. read_class (consultation vs bulk) is classified at log time; the circulation clock is pinned to kos ask landing.

Verified: cargo test green (27 tests, 7 new), clippy and fmt clean, end-to-end run produces per-session files whose id sets match orient's printed output, opt-out honored, no measurable slowdown (0.20s before and after).

Refs: aae-orc-2qlx0, aae-orc-jajn3, aae-orc-b0kp, aae-orc-1od3