### PR TITLE
feat: kos ask — ranked graph-proximity query verb (Phase 0)

### DIFF
--- a/_kos/probes/ask-eval-corpus/baseline-summary.md
+++ b/_kos/probes/ask-eval-corpus/baseline-summary.md
@@ -1,0 +1,119 @@
+# What kos ask has to beat: an honest read of grep and orient
+
+Written 2026-08-16, before `kos ask` was scored, so it cannot be tuned later to
+flatter the verb. This is the "what does the verb have to beat" statement the
+pre-registration node (`question-kos-ask-retrieval-value`) asks for. It is paired
+with `eval-corpus.md`, which holds the 15 questions and per-question baseline
+runs. Measurements are from ripgrep over the two graph roots and from Homebrew
+`kos alpha-20260809-030901-3495ed1 orient`.
+
+## The two baselines, stated fairly
+
+**grep reaches everything and ranks nothing.** `rg` searches every file in both
+graphs, including the 124 `.md` findings orient cannot see. When the query term
+is distinctive, grep is genuinely good: Q5 ("who pays / survival predictor")
+returns 3 files with the bedrock node first, and I would not expect the verb to
+do meaningfully better than that. grep's failures are all the same failure:
+no ranking, no tier awareness, no polarity. It cannot tell a graveyard node from
+the bedrock node that overturned it, and it cannot tell a common word from a rare
+one.
+
+**orient ranks by tier and is blind to most findings.** orient groups the graph
+into bedrock / frontier / graveyard / findings sections, which is a real
+advantage grep lacks: on ruled-out questions the reader jumps to a 7-to-10-item
+graveyard section instead of scanning a flat file list. But orient has two hard
+limits. It takes no query, so it dumps 222 to 269 lines and makes the reader
+triage all of it. And it reads only the 19 `.yaml` findings in the orc graph; it
+never surfaces any of the 124 `.md` findings. I confirmed finding-044 and
+finding-136 are absent from orient output. For a graph whose recent findings are
+almost all `.md`, that is most of the record.
+
+## Where the baselines already suffice
+
+The verb does not need to win everywhere, and I want the cases it does not need
+to win recorded up front.
+
+- **Distinctive-phrase point lookups.** Q5 (survival predictor) is solved by
+  grep in 3 files. The verb should match this and add the tier label; it will not
+  win by margin.
+- **Small-graveyard ruled-out questions.** Q8 (speckit / bmad format) lands in a
+  5-file grep and a 7-item orient graveyard section. Both baselines are already
+  fine. The bar here is "do not regress."
+- **Find-the-node questions where the node is `.yaml` and the wording matches.**
+  When the ground truth is a frontier `.yaml` node and the query uses its
+  vocabulary, orient lists it by name in the right section. The verb's job is to
+  save the reader the whole-dump scan, not to reach something orient cannot.
+
+## Where the baselines bury the answer
+
+This is the middle of the distribution, and it is where the verb earns or fails
+its keep.
+
+- **Common-word frontier questions.** Q13 ("director") is 124 grep files. The one
+  question node is one hit in 124. orient beats grep here by naming the node in
+  its open-questions section, but even orient cannot rank it or attach its `.md`
+  finding (finding-064). A verb that returns the director question and its
+  finding near the top, in one shot, is a large improvement over both.
+- **Popular-substring point lookups.** Q2 ("dolt server") is 27 grep files with
+  the two right answers scattered among two dozen bd-friction findings, and one
+  of those right answers (finding-039) is `.md` and invisible to orient. Neither
+  baseline serves this well.
+- **Idea-file-heavy frontier questions.** Q11 (charter management, 28 files) and
+  Q12 (active knowledge surfacing, 23 files) drown the question node under idea
+  files and cross-references. orient suppresses the idea noise but splits the
+  answer across two graphs and two sections.
+
+## Where neither baseline can answer at all
+
+- **`.md` finding lookups.** Q3 (finding-044) is unanswerable from orient by
+  construction, and grep only reaches it by brute force among decoys. Any
+  question whose answer is a `.md` finding is a place the verb can beat both
+  baselines at once, simply by reaching the file and ranking it. Given that 124
+  of 143 orc findings are `.md`, this is not an edge case; it is the common case
+  for anything decided since about finding-018.
+- **Cross-graph questions.** Q1, Q7, Q11, and Q12 have ground truth in both
+  graphs. orient is cwd-scoped and must run twice with a manual merge; grep can
+  search both roots at once but then ranks nothing. A verb that reads both graphs
+  and returns one ranked list is doing work neither baseline does. (The graphs
+  currently share ids across the boundary, for example `grv-kos-as-task-tracker`
+  in both, which the verb has to disambiguate rather than dedupe.)
+
+## The freshness and polarity gap
+
+Sub-question 4 of the node asks whether the verb can rank a bedrock node above a
+superseded one without a separate freshness model. The baselines set a low bar
+and a real one. grep gives no tier signal, so on Q9 (git as substrate) it lists
+the ruled-out graveyard node and the adopted bedrock storage model side by side,
+and a hurried reader can take the wrong one as the answer. orient does better:
+its tier sections keep ruled-out and adopted apart. So the verb's freshness
+target is orient, not grep. Matching grep's flat list would be a regression
+against the baseline that already exists.
+
+## The false-confidence bar
+
+Q14 and Q15 are the questions the graph cannot answer (a work-assignment lookup
+and a live-session absence-detection). Here the baselines have an accidental
+virtue: grep returns near-nothing and orient returns irrelevance, and because
+neither claims to have answered, neither misleads. The verb has a way to be worse
+than both, by returning a confident, well-ranked, wrong node. The node says this
+outright: a ranked answer that presents an untested or off-topic finding as
+authoritative is worse than grep, which at least hands over the raw file. So on
+these two the verb has to clear a bar the baselines clear for free: say nothing
+confident when there is nothing to say.
+
+## Summary judgment
+
+grep and orient already suffice on distinctive-phrase lookups and small-graveyard
+ruled-out questions, and the verb should aim only not to regress there. They both
+fail, in different ways, on the large middle: common-word and popular-substring
+questions where the answer is buried (grep) or unranked and dump-scale (orient),
+and on cross-graph questions that force two runs or a flat multi-root search.
+They both fail outright on `.md` finding lookups, which orient cannot see and
+grep reaches only by brute force, and that is the majority of the recent record.
+The verb's clearest wins are therefore reaching `.md` findings, ranking within a
+question, merging both graphs, and carrying tier for freshness. Its clearest risk
+is the false-confidence pair, where the honest answer is the empty one the
+baselines already give. If the verb ranks the buried middle, reaches the `.md`
+record, and still declines to answer Q14 and Q15, it beats what exists. If it
+wins the benchmark but sessions keep typing `rg`, the node has already ruled that
+a loss.

--- a/_kos/probes/ask-eval-corpus/eval-corpus.md
+++ b/_kos/probes/ask-eval-corpus/eval-corpus.md
@@ -1,0 +1,352 @@
+# kos ask evaluation corpus
+
+Scoring sheet for `kos ask` (bd `aae-orc-jajn3`, Phase 0), pre-registered by
+`kos/_kos/nodes/frontier/question-kos-ask-retrieval-value.yaml`. The node fixes
+the ordering before the verb ships: adoption dominates benchmark quality, and
+the corpus must be real session questions captured before anyone knows what the
+verb can do, so it cannot be gamed later.
+
+I assembled this on 2026-08-16 against the two graphs as they stood that day:
+`/Users/michael.pursifull/work/aae-orc/kos/_kos/` (the kos graph) and
+`/Users/michael.pursifull/work/aae-orc/_kos/` (the orc graph). A later session
+runs `kos ask <question>` against each entry and scores it on three axes the
+node names: ranking (did the right id come up near the top), freshness (did it
+prefer a bedrock or shipped answer over a superseded one), and provenance (did
+it hand back the id and tier, not a summary that hides its source).
+
+## How the questions were sourced
+
+Fifteen questions distilled from real session activity, not idealized. Sources,
+in order of weight:
+
+1. Verbatim user asks and agent self-directed searches mined from the eight
+   most recently modified session transcripts under
+   `/Users/michael.pursifull/.claude/projects/-Users-michael-pursifull-work-aae-orc/`.
+   The richest were `b9280faf` (identifier-collision work plus the `kos ask`
+   build itself), `f651f189` (one-surface guidance), and `e63284fc`
+   (bd/dolt/callbook topology).
+2. The shapes the pre-registration node itself names ("what was decided about
+   X, what was ruled out about Y, what is the open question on Z, where is the
+   finding about W").
+3. The standing frontier and graveyard nodes, which tell me what a session
+   genuinely needs to look up.
+
+Two real session shapes drove the design. The user's identifier-collision ask
+in `b9280faf` (L508, verbatim: "don't we have some work about dealing with
+identifier collusions ... Check our kos docs around this, and our findings and
+orc findings and most important bd ticket ...") is the canonical
+"point me at the prior decision, it spans findings and a bd ticket" shape. The
+"who is working finding-136?" ask appears verbatim in two separate sessions
+(`f651f189` L1003 and `e63284fc` L922); it looks like a graph lookup but is a
+work-assignment question the graph cannot answer, so it is one of my
+false-confidence probes.
+
+## What the baselines are
+
+**grep baseline.** The ripgrep an agent actually runs. I ran `rg -il <pattern>`
+over the graph roots and recorded the file count (the triage cost: how many
+files the reader opens to find the answer) and whether the right id is surfaced
+or buried among unrelated hits. Commands are recorded per question so the run
+is reproducible.
+
+**orient baseline.** `kos orient` (Homebrew `kos alpha-20260809-030901-3495ed1`).
+Two properties bound this baseline hard, and both were measured, not assumed:
+
+- orient takes no query. It dumps the whole graph for the current directory:
+  269 lines for the orc graph, 222 for the kos graph. The reader triages every
+  line by eye. Section sizes (orc / kos): open questions 68 / 43, bedrock 26 /
+  33, kos-findings 19 / 44, graveyard 7 / 10.
+- orient is cwd-scoped to one graph and reads only `.yaml` findings. The orc
+  graph has 19 `.yaml` findings and 124 `.md` findings; **orient surfaces none
+  of the 124 `.md` findings**. I confirmed finding-044 and finding-136 (both
+  `.md`) are absent from orient output. finding-128 in the graph documents this
+  same blindness for `kos reflect`. So for any question whose answer is a `.md`
+  finding, orient cannot reach it at all, and grep is the only baseline that
+  does.
+
+A note on freshness scoring (sub-question 4 of the node): orient groups by tier
+(bedrock / frontier / graveyard sections), which is a weak freshness signal the
+verb must at least match. grep gives no tier signal; it lists graveyard and
+bedrock hits undifferentiated. The verb has to beat orient's tier-grouping, not
+just grep's flat list.
+
+---
+
+## Kind (a): point lookups
+
+### Q1. What is the decision on the kos read path, how do sessions retrieve knowledge from the graph?
+- **Kind:** point lookup (spans both graphs)
+- **Session provenance:** the whole `kos ask` build in `b9280faf`; the read-path
+  gap is the subject of the pre-registration node.
+- **Ground truth:** `question-kos-ask-retrieval-value` (kos, frontier),
+  `question-read-telemetry-decision-value` (kos, frontier),
+  `question-read-surface-sequencing` (kos, frontier),
+  `val-retrieval-before-capture` (kos, **bedrock**, the load-bearing rule that
+  no capture ships before retrieval value is shown), `kos-read-path-gap.md`
+  (orc, idea), vision.md Gap 0.
+- **grep:** `rg -il 'read.path|read telemetry|kos ask' kos/_kos _kos` -> 12 files.
+  The three frontier questions and the idea surface, mixed with edge-vocabulary
+  and taxonomy noise (finding-044-edge-vocabulary, finding-033, finding-133,
+  finding-136). **Buried, and it misses the bedrock node**:
+  `val-retrieval-before-capture` does not contain the literal phrase, so grep
+  never returns the one bedrock answer that governs the whole area.
+- **orient:** answer is split across both graphs, so orient must run twice. The
+  frontier questions appear in the kos open-questions section (43 items) and the
+  bedrock value in the kos bedrock section (33 items); the orc idea is in a
+  section orient prints as 0 ideas for the orc, so orient does not list it.
+  Present but unranked, cross-graph, and the reader scans two full dumps.
+
+### Q2. What was decided about running bd on a Dolt server?
+- **Kind:** point lookup
+- **Session provenance:** `e63284fc` (bd/dolt topology session).
+- **Ground truth:** `question-bd-dolt-server-architecture` (orc, frontier),
+  finding-039-bd-localhost-dolt-server-phase-0-spike (orc, `.md`; Phase 0
+  shipped, bedrock promotion gated on soak), charter F26.
+- **grep:** `rg -il 'dolt server|dolt sql-server' _kos` -> **27 files**. The two
+  right answers sit among two dozen bd-friction findings that mention "dolt
+  server" in passing (finding-081, finding-101, finding-105, finding-115,
+  finding-124, and more). **Badly buried**; the highest-triage-cost point lookup
+  in the set.
+- **orient:** the frontier question appears in the orc open-questions section
+  (68 items). finding-039 is a `.md` finding, so **orient cannot surface it at
+  all**. The reader gets the question node but not the shipped-state finding.
+
+### Q3. Where is the finding about the bd versus bv ecosystem and the export-scope problem?
+- **Kind:** point lookup (find-the-finding)
+- **Session provenance:** the bd/bv confusion is live in `e63284fc` and
+  `b9280faf`.
+- **Ground truth:** finding-044-bd-bv-ecosystem-and-export-scope (orc, `.md`).
+- **grep:** `rg -il 'beads_viewer|bd.{0,3}bv|export scope' _kos` -> 9 files.
+  finding-044 is present but not distinguished from finding-081, finding-087,
+  finding-134 and three frontier nodes. Reader must open several to confirm.
+- **orient:** finding-044 is a `.md` finding, so **orient cannot surface it**.
+  This question is unanswerable from orient. grep is the only baseline that
+  reaches the target, and only by brute force.
+
+### Q4. What is the agent taxonomy, the five primitives?
+- **Kind:** point lookup
+- **Session provenance:** the taxonomy (persona/theme/identity/role/process)
+  recurs across sessions as the canonical vocabulary.
+- **Ground truth:** finding-019-agent-taxonomy (orc, `.md`), charter B14,
+  `question-persona-model` (orc, frontier, resolved to B14).
+- **grep:** `rg -il 'five primitive|agent taxonomy' _kos` -> 9 files. finding-019
+  surfaces (distinctive phrase), alongside idea files and finding-047. Reasonable
+  but not ranked; `question-persona-model` does not surface (different wording).
+- **orient:** B14 appears in the orc charter-items section (matched via the
+  bedrock node), which is a clean hit. But finding-019 (the full map) is `.md`,
+  so orient shows the charter line and not the finding behind it. Partial.
+
+### Q5. According to kos, what predicts whether a knowledge system survives?
+- **Kind:** point lookup (single authoritative node)
+- **Session provenance:** `elem-who-pays-survival-predictor` is cited directly in
+  the pre-registration node as the grounding for adoption-dominates.
+- **Ground truth:** `elem-who-pays-survival-predictor` (kos, **bedrock**).
+- **grep:** `rg -il 'who pays|survival predictor' kos/_kos` -> 3 files, the
+  bedrock node first. **Clean surface.** This is grep at its best: a distinctive
+  phrase with few decoys. The verb has to at least match this, and to add the
+  tier signal (that this is bedrock) that grep does not give.
+- **orient:** the node is in the kos bedrock section (33 items). Present,
+  tier-labeled, but the reader scans 33 lines to find it.
+
+---
+
+## Kind (b): ruled-out / negative
+
+### Q6. What was ruled out about pack management?
+- **Kind:** ruled-out (this is a literal `kos ask` test query the build session used)
+- **Ground truth:** `grv-skillshare-for-packs` (orc, **graveyard**), charter G1.
+  Positive counterpart for contrast: `elem-packs-in-marvel` (orc, bedrock).
+- **grep:** `rg -il 'pack management' _kos` -> 8 files. The graveyard node is
+  present but sits beside `elem-packs-in-marvel` (the opposite, positive
+  decision) and four sideshow idea files. **grep gives no signal that the
+  graveyard node is the ruled-out answer**; the reader infers it from the path.
+- **orient:** the orc graveyard section is only 7 items, so orient's tier
+  grouping lets the reader jump straight to graveyard and find
+  `grv-skillshare-for-packs` fast. **This is where orient beats grep**, and it
+  is the bar the verb must clear on negative questions.
+
+### Q7. Did we rule out using kos as a task tracker, and why?
+- **Kind:** ruled-out (spans both graphs)
+- **Session provenance:** the kos-versus-bd boundary is a recurring theme.
+- **Ground truth:** `grv-kos-as-task-tracker` (exists in **both** graphs, both
+  graveyard). Related: `question-kos-task-tracker-relationship` (orc, frontier).
+- **grep:** `rg -il 'task tracker' kos/_kos _kos` -> 10 files. The graveyard node
+  appears twice (once per graph, an id collision across graphs), among
+  `elem-kos`, ideas, and a probe. The duplicate is itself a hazard: the two
+  files are different content under the same id.
+- **orient:** each graveyard node shows in its own graph's graveyard section (7
+  and 10 items). Two runs, but tier grouping makes each easy. orient handles the
+  collision honestly by keeping them in separate graph dumps; grep flattens them
+  into one list.
+
+### Q8. Why did we not adopt speckit or the bmad document format?
+- **Kind:** ruled-out
+- **Ground truth:** `grv-speckit-adoption` (orc, graveyard),
+  `grv-bmad-format` (orc, graveyard), charter G2/G3.
+- **grep:** `rg -il 'speckit|bmad.{0,6}format' _kos` -> 5 files. Both graveyard
+  nodes surface among a probe and two ideas. **Reasonable**; distinctive terms
+  keep the decoys down.
+- **orient:** both in the 7-item orc graveyard section. Clean tier hit. Both
+  baselines do acceptably here; the verb must not regress.
+
+### Q9. Was git considered a sufficient substrate for kos, and why was that ruled out?
+- **Kind:** ruled-out
+- **Ground truth:** `grv-git-as-sufficient-substrate` (kos, graveyard),
+  `grv-git-semantic-layer` (kos, graveyard). Positive contrast:
+  `elem-storage-model` (kos, bedrock, "immutable fact store over git").
+- **grep:** `rg -il 'git.{0,12}substrate|sufficient substrate' kos/_kos` -> 11
+  files. The graveyard node is present but buried among substrate-hypothesis
+  findings (finding-036, finding-040) and the bedrock storage model, which is
+  the near-opposite conclusion. **The reader risks reading the positive node as
+  the answer.** Freshness/polarity matters and grep gives none.
+- **orient:** graveyard section (10 items) holds both ruled-out nodes; bedrock
+  section holds the storage model. Tier grouping separates ruled-out from
+  adopted, which is exactly the distinction grep loses.
+
+### Q10. Did we rule out flat-file context loading, and what was the measured ceiling?
+- **Kind:** ruled-out (with a specific fact: the ceiling)
+- **Ground truth:** `grv-flat-file-context-scaling` (kos, graveyard, "~20 epics").
+  Related bedrock: `elem-context-ceiling`.
+- **grep:** `rg -il 'flat.file|context ceiling|20 epics' kos/_kos` -> 12 files.
+  The graveyard node is present but buried among four findings and the bedrock
+  `elem-context-ceiling` (which states the ceiling positively). Reader must open
+  files to get the number.
+- **orient:** title-only, so even when it lists `grv-flat-file-context-scaling`
+  in the graveyard section, it does not carry the "~20 epics" fact. orient tells
+  you which node, never what it says. The verb should return the id and tier and
+  let the reader open one file, not twelve.
+
+---
+
+## Kind (c): open-question / frontier
+
+### Q11. What is still open on charter management?
+- **Kind:** frontier (spans both graphs)
+- **Session provenance:** charter re-inflation is a standing concern; the
+  charter-light-touch rule exists because of it.
+- **Ground truth:** `question-charter-management` (orc, frontier),
+  finding-008-charter-inflation (orc), finding-018-charter-management (orc),
+  finding-041-charter-inflation-as-graph-gap (kos), charter F22/F25.
+- **grep:** `rg -il 'charter management|charter.{0,4}inflation' _kos kos/_kos` ->
+  **28 files**. The question node is present but drowned; and the results include
+  the finding-018 id collision (two different orc files share finding-018) and
+  finding-068 (which is about a different collision). High triage cost.
+- **orient:** the question is in the orc open-questions section (68 items). Two
+  of the four ground-truth findings are `.md` and invisible to orient
+  (finding-008 and finding-018 are `.yaml`, so those two do show in the
+  19-item kos-findings section; finding-073 and the `.md` set do not). Partial
+  and split across two graphs.
+
+### Q12. What is the open question on active knowledge surfacing, the push side?
+- **Kind:** frontier
+- **Ground truth:** `question-active-knowledge-surfacing` (orc, frontier),
+  charter F19, finding-004-passive-graph-insufficient (orc, `.yaml`),
+  `elem-predictor-layer` (kos, frontier).
+- **grep:** `rg -il 'active knowledge|passive graph' _kos kos/_kos` -> **23 files**,
+  overwhelmingly idea files (prediction-engine, stage-rig, bd-orient-backdrop,
+  and a dozen more). The question node and finding-004 are in there but the
+  reader wades through 20-plus ideas first. Buried.
+- **orient:** the question node lists in the orc open-questions section;
+  finding-004 is `.yaml` so it does show in the 19-item kos-findings section.
+  Better than grep here because orient does not surface the idea-file noise, but
+  the reader still scans two sections across the dump.
+
+### Q13. What remains open on the director design and the agent communication protocol?
+- **Kind:** frontier
+- **Ground truth:** `question-director-design` (orc, frontier),
+  `elem-director` (orc, frontier), finding-064-director-control-channel-options
+  (orc, `.md`), charter F1/F3.
+- **grep:** `rg -il 'director' _kos` -> **124 files**. "director" is a common word
+  across the marvel and supervisor material, so grep is nearly useless: the one
+  question node is one hit in 124. **The strongest grep-buries-it case in the
+  set.**
+- **orient:** `question-director-design` appears by name in the orc
+  open-questions section, and orient also shows `elem-director` and the two
+  director briefs. So **orient sharply beats grep here** (scan one section of 68
+  vs open 124 files), though finding-064 (`.md`) stays invisible. This question
+  is the clearest case for a ranked verb: it must return the director question
+  and its `.md` finding, near the top, in one shot.
+
+---
+
+## False-confidence probes (the graph cannot answer these well)
+
+These exist so the corpus can measure whether the verb fabricates confidence.
+The success behavior is a miss, a low-confidence answer, or an explicit
+"the graph does not track this," not a confidently-ranked wrong node.
+
+### Q14. Who is working finding-136?
+- **Kind:** false-confidence (a work-assignment question wearing a lookup's clothes)
+- **Session provenance:** verbatim in two sessions (`f651f189` L1003,
+  `e63284fc` L922).
+- **Ground truth in the graph:** none for the question as asked. finding-136
+  (chat-as-probe-surface-harvest-gap) **exists** as a `.md` node, but it records
+  a knowledge gap, not who is assigned to it. Work assignment lives in bd and
+  git branches, which the kos graph does not track (see `grv-kos-as-task-tracker`
+  and the CLAUDE.md note that a bd claim does not even name an actor).
+- **grep:** `rg -il 'finding-136' _kos` -> 3 files (finding-136 itself, plus
+  finding-131 and finding-137 that cross-reference it). grep correctly returns
+  "here is the finding," which is honest, because grep never claims to answer
+  "who is working it."
+- **orient:** finding-136 is `.md`, so orient does not list it. orient returns
+  nothing, which is honest by omission.
+- **Failure mode to catch:** the verb confidently returns finding-136 as if it
+  answered "who is working it." The right answer is to surface the finding and
+  flag that assignment is a bd/git question the graph does not hold.
+
+### Q15. What did we not ticket this session, and what context will we lose when it compresses?
+- **Kind:** false-confidence (absence-detection about live session state)
+- **Session provenance:** verbatim `f651f189` L1132 and L1670 ("what did we not
+  ticket?").
+- **Ground truth in the graph:** none. This is a question about the absence of
+  records and about volatile session state; a static graph structurally cannot
+  answer it. It is precisely what the F19 predictor layer aspires to and does not
+  yet do (`question-active-knowledge-surfacing`, `elem-predictor-layer`).
+- **grep:** `rg -il 'did not ticket|not ticket|lose.{0,20}compress|context.{0,15}lost' _kos`
+  -> 1 file (finding-087, a false-positive match on "context lost"). grep
+  honestly returns near-nothing.
+- **orient:** dumps the whole graph, none of which answers the question. Honest
+  by irrelevance.
+- **Failure mode to catch:** the verb invents a plausible-looking answer (for
+  example, returning `question-active-knowledge-surfacing` as though it were the
+  answer rather than the reason there is no answer). A ranked, confident hit here
+  is worse than grep's empty result.
+
+---
+
+## Kind breakdown
+
+- Point lookup (a): Q1, Q2, Q3, Q4, Q5 (5)
+- Ruled-out / negative (b): Q6, Q7, Q8, Q9, Q10 (5)
+- Frontier / open (c): Q11, Q12, Q13 (3)
+- False-confidence (graph cannot answer): Q14, Q15 (2)
+- Total: 15
+
+## Scoring instructions for the later session
+
+For each question, run `kos ask "<question>"` and record:
+
+1. **Rank of first correct id.** Where in the answer list did a ground-truth id
+   appear (1 = top, or "absent")? For Q14/Q15 the correct behavior is no
+   confident hit, so a top-ranked node is a failure, not a success.
+2. **Freshness/polarity.** Did the verb prefer the bedrock or shipped answer over
+   a superseded or opposite-polarity one? Q5 (bedrock), Q6 and Q9 (graveyard vs
+   the positive counterpart) are the discriminating cases.
+3. **Provenance.** Did the answer carry the id and tier so the reader can open
+   the source, or did it hand back a summary that hides where it came from? The
+   node warns that a confident summary of an untested finding is worse than grep.
+4. **`.md` reach.** Q2, Q3, Q13, Q14 have `.md`-finding ground truth that orient
+   cannot see. Did the verb reach them? This is the clearest place the verb can
+   beat both baselines at once.
+5. **Proximity lift (success signal b).** For at least one question, did a
+   correct hit come from graph proximity rather than lexical match, that is, a
+   hit grep's pattern did not contain? Q1 (the bedrock `val-retrieval-before-
+   capture` that grep missed) and Q9 (polarity separation) are the best
+   candidates.
+
+The pre-registered success signal, restated: over the ten sessions after the
+verb ships, `kos ask` is invoked in at least half the sessions that consult the
+graph at all, and at least one session records an answer through a hit the
+lexical set did not contain. Both halves required. This corpus measures the
+second half directly and gives the first half an honest baseline to be judged
+against.

--- a/src/ask.rs
+++ b/src/ask.rs
@@ -1,0 +1,806 @@
+//! Ask: ranked, scoped retrieval over the knowledge graph.
+//!
+//! `grep` hands back a location and cannot order what it finds; an unfiltered
+//! `orient` hands back the whole graph and makes the reader triage it. `ask`
+//! sits between them: it ranks nodes and findings by lexical match strength,
+//! boosts an item that cites or is cited by a strong hit (so a match the plain
+//! word search would have missed can still surface), and carries provenance
+//! (id, type, confidence tier, date) and freshness (superseded and ruled-out
+//! items are shown as such, never silently returned as current) on every row.
+//!
+//! Phase 0 substrate is lexical matching plus graph proximity, nothing heavier.
+//! The verb is the durable contract; the substrate is meant to change under it.
+//! See `docs/proposals/read-path-first-steps.md` and the frontier node
+//! `question-kos-ask-retrieval-value`.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{KosError, Result};
+use crate::model::{Confidence, EdgeType, Node, NodeType};
+use crate::orient;
+use crate::telemetry::{self, ReadClass, ReadEvent};
+use crate::workspace::{KOS_DIR, Workspace};
+
+// ── Ranking weights ──────────────────────────────────────────
+//
+// Curated ids and titles are strong signal; body text is weak and capped so a
+// long node that happens to repeat a word cannot outweigh a titled match.
+
+/// A query term found in a node id.
+const W_ID: f64 = 6.0;
+/// A query term found in a node title.
+const W_TITLE: f64 = 4.0;
+/// Each occurrence of a query term in body content, up to `CONTENT_CAP`.
+const W_CONTENT: f64 = 0.6;
+/// Content occurrences past this add nothing (a long node is not more relevant
+/// for saying the same word ten times).
+const CONTENT_CAP: usize = 4;
+/// Fraction of a neighbor's lexical score that flows to an adjacent node.
+const PROX_FACTOR: f64 = 0.3;
+/// Multiplier applied to a node another node supersedes.
+const SUPERSEDED_MULT: f64 = 0.75;
+/// Scores at or below this are treated as no match.
+const EPS: f64 = 1e-9;
+
+// Snippet window sizes, in bytes (clamped to char boundaries before slicing).
+const WIN_BEFORE: usize = 48;
+const WIN_AFTER: usize = 132;
+const WIN_HEAD: usize = 140;
+
+/// Grammatical words that carry no retrieval signal. Dropped before scoring so
+/// "what was ruled out about pack management" ranks on "ruled out pack
+/// management", not on "what" and "was". Kept deliberately small: only pure
+/// function words, never content words like "out" or "not".
+const STOPWORDS: &[&str] = &[
+    "a", "an", "the", "of", "to", "in", "on", "for", "and", "or", "is", "are", "was", "were", "be",
+    "been", "being", "what", "how", "does", "do", "did", "with", "that", "this", "about", "i",
+    "we", "it", "as", "at", "by", "from", "can", "will", "would", "should",
+];
+
+/// How current a result is, relative to the rest of the graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Freshness {
+    /// Live knowledge.
+    Current,
+    /// Another node supersedes this one.
+    Superseded,
+    /// Ruled out (graveyard tier). Returned, not hidden, so a stale answer is
+    /// visibly stale.
+    RuledOut,
+}
+
+impl Freshness {
+    fn as_str(self) -> &'static str {
+        match self {
+            Freshness::Current => "current",
+            Freshness::Superseded => "superseded",
+            Freshness::RuledOut => "ruled_out",
+        }
+    }
+
+    /// Sort key: current before superseded before ruled-out, at equal score.
+    fn rank(self) -> u8 {
+        match self {
+            Freshness::Current => 0,
+            Freshness::Superseded => 1,
+            Freshness::RuledOut => 2,
+        }
+    }
+}
+
+/// One ranked result, with the provenance and freshness a bare grep line lacks.
+#[derive(Debug)]
+pub struct AskResult {
+    pub id: String,
+    pub node_type: NodeType,
+    pub confidence: Confidence,
+    pub title: String,
+    /// The final relevance score (lexical, proximity-boosted, tier-weighted).
+    pub score: f64,
+    /// A short slice of matching body text, whitespace collapsed.
+    pub snippet: String,
+    /// Creation date when the node records one (findings almost always do).
+    pub date: Option<String>,
+    pub freshness: Freshness,
+    /// Set only when the item had no lexical hit of its own and surfaced
+    /// through graph proximity: the strongest neighbor that pulled it in. This
+    /// is the case where proximity did work grep could not have done.
+    pub via: Option<String>,
+    pub is_finding: bool,
+}
+
+/// Run the ask subcommand: resolve the graph, rank the corpus, print, log.
+pub fn run(
+    workspace: &Workspace,
+    cwd: &Path,
+    target: Option<&str>,
+    query: &str,
+    limit: usize,
+    json: bool,
+) -> Result<()> {
+    let (graph_dir, label) = resolve_graph(workspace, cwd, target);
+    let corpus = load_corpus(&graph_dir)?;
+    let total = corpus.len();
+    let results = rank(&corpus, query, limit);
+
+    if json {
+        print_json(&results);
+    } else {
+        print_human(query, &label, total, &results);
+    }
+
+    // Consultation-class read: the served set is narrowed by the question, so
+    // it can evidence adoption in the read telemetry. Fail-open exactly like
+    // orient; a read verb must never fail because its own telemetry failed.
+    if telemetry::enabled() {
+        let event = ReadEvent {
+            verb: "ask",
+            target: &label,
+            read_class: ReadClass::Consultation,
+            json_output: json,
+            node_ids: results
+                .iter()
+                .filter(|r| !r.is_finding)
+                .map(|r| r.id.as_str())
+                .collect(),
+            finding_ids: results
+                .iter()
+                .filter(|r| r.is_finding)
+                .map(|r| r.id.as_str())
+                .collect(),
+        };
+        if let Err(e) = telemetry::record_reads(&graph_dir, &event) {
+            eprintln!("warning: could not write read telemetry: {e}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Rank a corpus of nodes against a query. Pure: no IO, deterministic order.
+///
+/// Three passes: lexical base score per item; a graph-proximity boost that
+/// lets an item near a strong hit surface even with no lexical match of its
+/// own; a tier and freshness weighting so bedrock outranks a ruled-out node at
+/// equal lexical strength and superseded items are penalized but still shown.
+pub fn rank(corpus: &[Node], query: &str, limit: usize) -> Vec<AskResult> {
+    let terms = tokenize(query);
+    if terms.is_empty() || corpus.is_empty() {
+        return Vec::new();
+    }
+
+    // id → index, for resolving edge targets to corpus positions.
+    let mut index: std::collections::HashMap<&str, usize> =
+        std::collections::HashMap::with_capacity(corpus.len());
+    for (i, node) in corpus.iter().enumerate() {
+        index.insert(node.id.as_str(), i);
+    }
+
+    // Nodes some other node supersedes. `supersedes` points newer → older, so
+    // the edge target is the stale one.
+    let mut superseded: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for node in corpus {
+        for edge in node.all_edges() {
+            if matches!(edge.edge_type, EdgeType::Supersedes) {
+                superseded.insert(edge.target);
+            }
+        }
+    }
+
+    let base: Vec<f64> = corpus.iter().map(|n| lexical_score(n, &terms)).collect();
+
+    // Undirected adjacency for proximity: a node ranks up whether it cites a
+    // strong hit or is cited by one.
+    let mut neighbors: Vec<std::collections::HashSet<usize>> =
+        vec![std::collections::HashSet::new(); corpus.len()];
+    for (i, node) in corpus.iter().enumerate() {
+        for edge in node.all_edges() {
+            if let Some(&j) = index.get(edge.target.as_str()) {
+                if j != i {
+                    neighbors[i].insert(j);
+                    neighbors[j].insert(i);
+                }
+            }
+        }
+    }
+
+    let mut results: Vec<AskResult> = Vec::new();
+    for (i, node) in corpus.iter().enumerate() {
+        let mut boost = 0.0;
+        let mut best_via: Option<(f64, &str)> = None;
+        for &j in &neighbors[i] {
+            if base[j] > EPS {
+                boost += PROX_FACTOR * base[j];
+                if best_via.is_none_or(|(b, _)| base[j] > b) {
+                    best_via = Some((base[j], corpus[j].id.as_str()));
+                }
+            }
+        }
+
+        let combined = base[i] + boost;
+        if combined <= EPS {
+            continue;
+        }
+
+        let is_superseded = superseded.contains(&node.id);
+        let mut score = combined * tier_mult(&node.confidence);
+        if is_superseded {
+            score *= SUPERSEDED_MULT;
+        }
+
+        let freshness = if node.confidence == Confidence::Graveyard {
+            Freshness::RuledOut
+        } else if is_superseded {
+            Freshness::Superseded
+        } else {
+            Freshness::Current
+        };
+
+        let via = if base[i] <= EPS {
+            best_via.map(|(_, id)| id.to_string())
+        } else {
+            None
+        };
+
+        results.push(AskResult {
+            id: node.id.clone(),
+            node_type: node.node_type.clone(),
+            confidence: node.confidence.clone(),
+            title: node.title.clone(),
+            score,
+            snippet: snippet(&node.content, &terms),
+            date: node.provenance.as_ref().and_then(|p| p.created_at.clone()),
+            freshness,
+            via,
+            is_finding: node.node_type == NodeType::Finding,
+        });
+    }
+
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.freshness.rank().cmp(&b.freshness.rank()))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    results.truncate(limit);
+    results
+}
+
+/// Split a query into scored terms: alphanumeric words of two or more chars,
+/// lowercased, function words dropped, de-duplicated. If the query is nothing
+/// but stopwords, fall back to the raw tokens rather than searching for
+/// nothing.
+fn tokenize(query: &str) -> Vec<String> {
+    let raw: Vec<String> = query
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| w.chars().count() >= 2)
+        .map(str::to_lowercase)
+        .collect();
+
+    let mut kept: Vec<String> = raw
+        .iter()
+        .filter(|w| !STOPWORDS.contains(&w.as_str()))
+        .cloned()
+        .collect();
+
+    let source = if kept.is_empty() {
+        raw
+    } else {
+        std::mem::take(&mut kept)
+    };
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    source
+        .into_iter()
+        .filter(|w| seen.insert(w.clone()))
+        .collect()
+}
+
+/// Lexical relevance of one node to the query terms. Title and id hits weigh
+/// heavily; body hits are weak and capped; matching more distinct query terms
+/// (coverage) lifts the score so a node hitting every term beats one hitting a
+/// single term repeatedly.
+fn lexical_score(node: &Node, terms: &[String]) -> f64 {
+    let id = node.id.to_lowercase();
+    let title = node.title.to_lowercase();
+    let content = node.content.to_lowercase();
+
+    let mut score = 0.0;
+    let mut hits = 0usize;
+    for term in terms {
+        let mut hit = false;
+        if id.contains(term.as_str()) {
+            score += W_ID;
+            hit = true;
+        }
+        if title.contains(term.as_str()) {
+            score += W_TITLE;
+            hit = true;
+        }
+        let occ = content.matches(term.as_str()).count();
+        if occ > 0 {
+            score += W_CONTENT * occ.min(CONTENT_CAP) as f64;
+            hit = true;
+        }
+        if hit {
+            hits += 1;
+        }
+    }
+
+    if hits == 0 {
+        return 0.0;
+    }
+    let coverage = hits as f64 / terms.len() as f64;
+    score * (0.5 + 0.5 * coverage)
+}
+
+/// Freshness weighting by confidence tier: bedrock outranks a ruled-out node at
+/// equal lexical strength, but graveyard nodes still score above zero so they
+/// are surfaced (with their status) rather than hidden.
+fn tier_mult(confidence: &Confidence) -> f64 {
+    match confidence {
+        Confidence::Bedrock => 1.2,
+        Confidence::Frontier => 1.0,
+        Confidence::Placeholder => 0.85,
+        Confidence::Graveyard => 0.55,
+    }
+}
+
+/// A short body slice around the first query-term hit, whitespace collapsed.
+/// When nothing matched in the body (a title, id, or proximity-only result),
+/// show the head of the content instead.
+fn snippet(content: &str, terms: &[String]) -> String {
+    if content.trim().is_empty() {
+        return String::new();
+    }
+    let lc = content.to_lowercase();
+    let first = terms.iter().filter_map(|t| lc.find(t.as_str())).min();
+
+    let window = match first {
+        Some(pos) => {
+            let start = floor_boundary(content, pos.saturating_sub(WIN_BEFORE));
+            let end = floor_boundary(content, (pos + WIN_AFTER).min(content.len()));
+            let mut s = String::new();
+            if start > 0 {
+                s.push_str("...");
+            }
+            s.push_str(&content[start..end]);
+            if end < content.len() {
+                s.push_str("...");
+            }
+            s
+        }
+        None => {
+            let end = floor_boundary(content, WIN_HEAD.min(content.len()));
+            let mut s = content[..end].to_string();
+            if end < content.len() {
+                s.push_str("...");
+            }
+            s
+        }
+    };
+
+    window.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Largest char boundary at or below `i`, so a byte-index window never slices
+/// through a multi-byte character.
+fn floor_boundary(s: &str, mut i: usize) -> usize {
+    if i >= s.len() {
+        return s.len();
+    }
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+// ── Corpus loading ───────────────────────────────────────────
+
+/// Load the search corpus for a graph: every node (all tiers) plus every
+/// finding. Findings are read as nodes so their citation edges and dates join
+/// the graph the ranking walks. Reuses `orient`'s node loader; see
+/// `load_findings_as_nodes` for the one legacy shape it cannot parse.
+pub fn load_corpus(graph_dir: &Path) -> Result<Vec<Node>> {
+    let mut corpus = orient::load_all_nodes(&graph_dir.join("nodes"))?;
+    corpus.extend(load_findings_as_nodes(&graph_dir.join("findings"))?);
+    Ok(corpus)
+}
+
+/// Load findings as nodes. Findings carry id/type/confidence/title/edges/
+/// provenance, so they deserialize as `Node` directly, which keeps their
+/// (heavily cited) edges and their `created_at` dates in the corpus. One
+/// legacy finding stores its prose under `finding.summary`/`detail` with no
+/// top-level `content`; that one is retried through `finding_node_fallback`
+/// before it would be dropped. Parse failures are skipped silently: a
+/// malformed finding is not `ask`'s error to report.
+fn load_findings_as_nodes(dir: &Path) -> Result<Vec<Node>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in walkdir::WalkDir::new(dir)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+    {
+        let path = entry.path();
+        let ext = path.extension().and_then(|e| e.to_str());
+        if !path.is_file() || (ext != Some("yaml") && ext != Some("yml")) {
+            continue;
+        }
+        let text = std::fs::read_to_string(path).map_err(KosError::Io)?;
+        match serde_yaml::from_str::<Node>(&text) {
+            Ok(mut node) => {
+                node.source_path = path.to_path_buf();
+                out.push(node);
+            }
+            Err(_) => {
+                if let Some(mut node) = finding_node_fallback(&text) {
+                    node.source_path = path.to_path_buf();
+                    out.push(node);
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Build a searchable node from a finding whose prose lives under the `finding`
+/// block instead of a top-level `content` field. Pulls id, title, and confidence
+/// from the top level and flattens the `finding` block into content so the text
+/// is still matchable.
+fn finding_node_fallback(text: &str) -> Option<Node> {
+    let value: serde_yaml::Value = serde_yaml::from_str(text).ok()?;
+    let id = value.get("id")?.as_str()?.to_string();
+    let title = value
+        .get("title")
+        .and_then(serde_yaml::Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let content = value
+        .get("finding")
+        .and_then(|f| serde_yaml::to_string(f).ok())
+        .unwrap_or_default();
+
+    Some(Node {
+        id,
+        node_type: NodeType::Finding,
+        confidence: Confidence::Frontier,
+        title,
+        content,
+        edges: Vec::new(),
+        depends_on: Vec::new(),
+        graveyard: None,
+        brief: None,
+        finding: None,
+        compaction: None,
+        provenance: None,
+        tags: Vec::new(),
+        notes: None,
+        source_path: PathBuf::new(),
+    })
+}
+
+/// Resolve which graph to search and the label to log it under. An explicit
+/// `--target` naming a discovered graph wins; otherwise mirror the resolution
+/// `orient` uses for where it logs a read.
+fn resolve_graph(workspace: &Workspace, cwd: &Path, target: Option<&str>) -> (PathBuf, String) {
+    if let Some(t) = target {
+        if let Some(graph) = workspace.graphs.iter().find(|g| g.graph_id == t) {
+            return (graph.path.clone(), graph.graph_id.clone());
+        }
+    }
+
+    let (dir, default_label) = if workspace.is_standalone() {
+        let dir = workspace.root.join(KOS_DIR);
+        let label = workspace
+            .graphs
+            .iter()
+            .find(|g| g.path == dir)
+            .map(|g| g.graph_id.clone())
+            .unwrap_or_else(|| "kos".to_string());
+        (dir, label)
+    } else if let Some(graph) = workspace.nearest_graph(cwd) {
+        (graph.path.clone(), graph.graph_id.clone())
+    } else {
+        (workspace.node_root(), "kos".to_string())
+    };
+
+    let label = target.map(str::to_string).unwrap_or(default_label);
+    (dir, label)
+}
+
+// ── Output ───────────────────────────────────────────────────
+
+fn print_human(query: &str, label: &str, total: usize, results: &[AskResult]) {
+    println!("=== kos ask: \"{query}\" ({label}) ===\n");
+
+    if results.is_empty() {
+        println!("  no matches among {total} nodes and findings searched");
+        println!("  try broader terms, or `kos orient` for the full graph");
+        return;
+    }
+
+    println!(
+        "{} result(s), ranked (of {total} searched)\n",
+        results.len()
+    );
+    for (rank, r) in results.iter().enumerate() {
+        println!("  {}. {}", rank + 1, r.id);
+
+        let mut meta = format!("score {:.1} | {} | {}", r.score, r.node_type, r.confidence);
+        if let Some(ref date) = r.date {
+            meta.push_str(" | ");
+            meta.push_str(date);
+        }
+        match r.freshness {
+            Freshness::RuledOut => meta.push_str(" | RULED OUT"),
+            Freshness::Superseded => meta.push_str(" | SUPERSEDED"),
+            Freshness::Current => {}
+        }
+        println!("     {meta}");
+        println!("     {}", r.title);
+        if let Some(ref via) = r.via {
+            println!("     via graph proximity from {via}");
+        }
+        if !r.snippet.is_empty() {
+            println!("     > {}", r.snippet);
+        }
+        println!();
+    }
+}
+
+fn print_json(results: &[AskResult]) {
+    let arr: Vec<serde_json::Value> = results
+        .iter()
+        .enumerate()
+        .map(|(rank, r)| {
+            serde_json::json!({
+                "rank": rank + 1,
+                "id": r.id,
+                "type": r.node_type.to_string(),
+                "confidence": r.confidence.to_string(),
+                "score": (r.score * 1000.0).round() / 1000.0,
+                "title": r.title,
+                "snippet": r.snippet,
+                "date": r.date,
+                "freshness": r.freshness.as_str(),
+                "via": r.via,
+                "is_finding": r.is_finding,
+            })
+        })
+        .collect();
+
+    let json = serde_json::to_string_pretty(&arr).unwrap_or_else(|_| "[]".to_string());
+    println!("{json}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Edge;
+
+    fn node(
+        id: &str,
+        tier: Confidence,
+        node_type: NodeType,
+        title: &str,
+        content: &str,
+        edges: &[(&str, EdgeType)],
+    ) -> Node {
+        Node {
+            id: id.to_string(),
+            node_type,
+            confidence: tier,
+            title: title.to_string(),
+            content: content.to_string(),
+            edges: edges
+                .iter()
+                .map(|(target, edge_type)| Edge {
+                    target: (*target).to_string(),
+                    edge_type: edge_type.clone(),
+                    signal: None,
+                    note: None,
+                })
+                .collect(),
+            depends_on: Vec::new(),
+            graveyard: None,
+            brief: None,
+            finding: None,
+            compaction: None,
+            provenance: None,
+            tags: Vec::new(),
+            notes: None,
+            source_path: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn tokenize_drops_stopwords_keeps_content_words() {
+        assert_eq!(
+            tokenize("what was ruled out about pack management"),
+            vec!["ruled", "out", "pack", "management"]
+        );
+    }
+
+    #[test]
+    fn tokenize_dedupes_and_falls_back_when_all_stopwords() {
+        assert_eq!(tokenize("the the of to"), vec!["the", "of", "to"]);
+        assert_eq!(tokenize("pack pack management"), vec!["pack", "management"]);
+    }
+
+    #[test]
+    fn title_hit_outranks_content_only_hit() {
+        let corpus = vec![
+            node(
+                "elem-a",
+                Confidence::Frontier,
+                NodeType::Element,
+                "telemetry decision",
+                "unrelated body",
+                &[],
+            ),
+            node(
+                "elem-b",
+                Confidence::Frontier,
+                NodeType::Element,
+                "unrelated title",
+                "a passing mention of telemetry in the body",
+                &[],
+            ),
+        ];
+        let results = rank(&corpus, "telemetry", 10);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].id, "elem-a");
+        assert!(results[0].score > results[1].score);
+    }
+
+    #[test]
+    fn bedrock_outranks_graveyard_at_equal_lexical() {
+        let corpus = vec![
+            node(
+                "elem-grave",
+                Confidence::Graveyard,
+                NodeType::Element,
+                "pack management approach",
+                "",
+                &[],
+            ),
+            node(
+                "elem-rock",
+                Confidence::Bedrock,
+                NodeType::Element,
+                "pack management approach",
+                "",
+                &[],
+            ),
+        ];
+        let results = rank(&corpus, "pack management", 10);
+        assert_eq!(results[0].id, "elem-rock");
+        assert_eq!(results[0].freshness, Freshness::Current);
+    }
+
+    #[test]
+    fn graveyard_is_surfaced_not_hidden() {
+        let corpus = vec![node(
+            "grv-monolith",
+            Confidence::Graveyard,
+            NodeType::Graveyard,
+            "monolith approach for pack management",
+            "ruled out",
+            &[],
+        )];
+        let results = rank(&corpus, "pack management", 10);
+        assert_eq!(results.len(), 1, "a ruled-out match must still be returned");
+        assert_eq!(results[0].freshness, Freshness::RuledOut);
+    }
+
+    #[test]
+    fn proximity_surfaces_a_node_with_no_lexical_hit() {
+        // elem-b matches nothing lexically, but cites the strong hit elem-a.
+        let with_edge = vec![
+            node(
+                "elem-a",
+                Confidence::Frontier,
+                NodeType::Element,
+                "telemetry read path",
+                "",
+                &[],
+            ),
+            node(
+                "elem-b",
+                Confidence::Frontier,
+                NodeType::Element,
+                "unrelated",
+                "nothing here",
+                &[("elem-a", EdgeType::Derives)],
+            ),
+        ];
+        let results = rank(&with_edge, "telemetry", 10);
+        let b = results.iter().find(|r| r.id == "elem-b");
+        assert!(b.is_some(), "proximity should surface the citing node");
+        assert_eq!(b.unwrap().via.as_deref(), Some("elem-a"));
+
+        // Remove the edge and elem-b must disappear: the edge, not the text,
+        // put it in the result set.
+        let without_edge = vec![
+            node(
+                "elem-a",
+                Confidence::Frontier,
+                NodeType::Element,
+                "telemetry read path",
+                "",
+                &[],
+            ),
+            node(
+                "elem-b",
+                Confidence::Frontier,
+                NodeType::Element,
+                "unrelated",
+                "nothing here",
+                &[],
+            ),
+        ];
+        let results = rank(&without_edge, "telemetry", 10);
+        assert!(results.iter().all(|r| r.id != "elem-b"));
+    }
+
+    #[test]
+    fn superseded_node_is_flagged() {
+        let corpus = vec![
+            node(
+                "elem-old",
+                Confidence::Frontier,
+                NodeType::Element,
+                "pack management v1",
+                "",
+                &[],
+            ),
+            node(
+                "elem-new",
+                Confidence::Frontier,
+                NodeType::Element,
+                "pack management v2",
+                "",
+                &[("elem-old", EdgeType::Supersedes)],
+            ),
+        ];
+        let results = rank(&corpus, "pack management", 10);
+        let old = results.iter().find(|r| r.id == "elem-old").unwrap();
+        assert_eq!(old.freshness, Freshness::Superseded);
+        let new = results.iter().find(|r| r.id == "elem-new").unwrap();
+        assert_eq!(new.freshness, Freshness::Current);
+    }
+
+    #[test]
+    fn empty_query_returns_nothing() {
+        let corpus = vec![node(
+            "elem-a",
+            Confidence::Frontier,
+            NodeType::Element,
+            "title",
+            "body",
+            &[],
+        )];
+        assert!(rank(&corpus, "   ", 10).is_empty());
+    }
+
+    #[test]
+    fn limit_truncates_results() {
+        let corpus: Vec<Node> = (0..5)
+            .map(|i| {
+                node(
+                    &format!("elem-{i}"),
+                    Confidence::Frontier,
+                    NodeType::Element,
+                    "pack management",
+                    "",
+                    &[],
+                )
+            })
+            .collect();
+        assert_eq!(rank(&corpus, "pack management", 3).len(), 3);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+pub mod ask;
 pub mod bridge;
 pub mod charter;
 pub mod compact;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,34 @@ enum Commands {
         ready: bool,
     },
 
+    /// Ask a question — ranked, scoped retrieval over the knowledge graph
+    ///
+    /// Searches the nearest graph's nodes and findings, ranks them by lexical
+    /// match strength boosted by graph proximity, and carries provenance
+    /// (id, type, confidence tier, date) and freshness (superseded and
+    /// ruled-out items are shown as such, not hidden) on every result.
+    Ask {
+        /// The question to search for (one or more words)
+        #[arg(required = true, num_args = 1..)]
+        question: Vec<String>,
+
+        /// Path to the aae-orc workspace root (env: KOS_WORKSPACE)
+        #[arg(long, env = "KOS_WORKSPACE")]
+        workspace: Option<PathBuf>,
+
+        /// Scope to a single named graph (its graph_id); defaults to the nearest graph
+        #[arg(long)]
+        target: Option<String>,
+
+        /// Maximum number of results to return
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+
+        /// Output as a JSON array instead of human-readable text
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Validate nodes against the schema (nearest graph by default)
     ///
     /// Validates the graph nearest to the current directory: the local
@@ -264,6 +292,27 @@ fn main() -> anyhow::Result<()> {
                 .unwrap_or_else(|| "kos".to_string());
 
             kos::orient::run(&workspace, &target, json, log, ready)?;
+        }
+
+        Commands::Ask {
+            question,
+            workspace: workspace_path,
+            target,
+            limit,
+            json,
+        } => {
+            let cwd = std::env::current_dir()?;
+
+            let workspace = kos::workspace::Workspace::discover(&cwd).or_else(|discover_err| {
+                if let Some(ref ws_path) = workspace_path {
+                    kos::workspace::Workspace::from_explicit(ws_path)
+                } else {
+                    Err(discover_err)
+                }
+            })?;
+
+            let query = question.join(" ");
+            kos::ask::run(&workspace, &cwd, target.as_deref(), &query, limit, json)?;
         }
 
         Commands::Validate { merged } => {

--- a/src/orient.rs
+++ b/src/orient.rs
@@ -281,7 +281,7 @@ fn run_ready(workspace: &Workspace, cwd: &Path, target: &str, json: bool) -> Res
     Ok(())
 }
 
-fn load_all_nodes(nodes_dir: &Path) -> Result<Vec<Node>> {
+pub(crate) fn load_all_nodes(nodes_dir: &Path) -> Result<Vec<Node>> {
     let mut results = Vec::new();
     for entry in walkdir::WalkDir::new(nodes_dir)
         .into_iter()

--- a/tests/ask_ranking.rs
+++ b/tests/ask_ranking.rs
@@ -1,0 +1,112 @@
+//! Integration tests for `kos ask` (aae-orc-jajn3,
+//! question-kos-ask-retrieval-value).
+//!
+//! Exercises the corpus loader and ranker against an on-disk fixture graph:
+//! the loader must fold nodes and findings into one corpus, and the ranker
+//! must (1) rank a title hit above a body-only hit, (2) surface a ruled-out
+//! node as ruled-out rather than hiding it, and (3) surface a node that only
+//! matched through a citation edge.
+
+use std::fs;
+use std::path::Path;
+
+use kos::ask::{self, Freshness};
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+/// A small graph: a strong frontier hit, a ruled-out node, a citing node with
+/// no lexical match, and a finding (loaded from findings/, carrying a date).
+fn fixture(root: &Path) {
+    write(
+        &root.join("_kos/kos.yaml"),
+        "graph_id: fixture\nscope: repo\nschema_version: '0.3'\n",
+    );
+    write(
+        &root.join("_kos/nodes/frontier/question-read-telemetry.yaml"),
+        "id: question-read-telemetry\ntype: question\nconfidence: frontier\n\
+         title: \"Should kos record read telemetry?\"\n\
+         content: \"Telemetry logs which nodes a read verb served.\"\n",
+    );
+    write(
+        &root.join("_kos/nodes/graveyard/grv-telemetry-gate.yaml"),
+        "id: grv-telemetry-gate\ntype: graveyard\nconfidence: graveyard\n\
+         title: \"Gate merges on telemetry counts\"\n\
+         content: \"Ruled out: telemetry is diagnostic, not a gate.\"\n",
+    );
+    write(
+        &root.join("_kos/nodes/frontier/question-active-surfacing.yaml"),
+        "id: question-active-surfacing\ntype: question\nconfidence: frontier\n\
+         title: \"Active knowledge surfacing\"\n\
+         content: \"The push half of the read problem.\"\n\
+         edges:\n  - target: question-read-telemetry\n    type: derives\n",
+    );
+    write(
+        &root.join("_kos/findings/finding-100-read-path.yaml"),
+        "id: finding-100-read-path\ntype: finding\nconfidence: frontier\n\
+         title: \"Read path telemetry shipped\"\n\
+         content: \"The telemetry module logs served ids per session.\"\n\
+         provenance:\n  created_at: \"2026-08-16\"\n",
+    );
+}
+
+#[test]
+fn corpus_folds_nodes_and_findings() {
+    let tmp = tempfile::tempdir().unwrap();
+    fixture(tmp.path());
+
+    let corpus = ask::load_corpus(&tmp.path().join("_kos")).unwrap();
+    // 3 nodes + 1 finding.
+    assert_eq!(corpus.len(), 4);
+    assert!(corpus.iter().any(|n| n.id == "finding-100-read-path"));
+}
+
+#[test]
+fn title_hit_leads_and_finding_carries_date() {
+    let tmp = tempfile::tempdir().unwrap();
+    fixture(tmp.path());
+    let corpus = ask::load_corpus(&tmp.path().join("_kos")).unwrap();
+
+    let results = ask::rank(&corpus, "read telemetry", 10);
+    assert!(!results.is_empty());
+    // The finding titles "Read path telemetry shipped" and hits both terms in
+    // the title, so it leads; and it carries its provenance date.
+    let finding = results
+        .iter()
+        .find(|r| r.id == "finding-100-read-path")
+        .expect("finding should rank");
+    assert_eq!(finding.date.as_deref(), Some("2026-08-16"));
+    assert!(finding.is_finding);
+}
+
+#[test]
+fn ruled_out_node_is_surfaced_with_status() {
+    let tmp = tempfile::tempdir().unwrap();
+    fixture(tmp.path());
+    let corpus = ask::load_corpus(&tmp.path().join("_kos")).unwrap();
+
+    let results = ask::rank(&corpus, "telemetry", 10);
+    let grave = results
+        .iter()
+        .find(|r| r.id == "grv-telemetry-gate")
+        .expect("a ruled-out match must still be returned");
+    assert_eq!(grave.freshness, Freshness::RuledOut);
+}
+
+#[test]
+fn proximity_surfaces_the_citing_question() {
+    let tmp = tempfile::tempdir().unwrap();
+    fixture(tmp.path());
+    let corpus = ask::load_corpus(&tmp.path().join("_kos")).unwrap();
+
+    // question-active-surfacing does not contain "telemetry"; it only cites the
+    // node that does. Proximity must pull it in and name the neighbor.
+    let results = ask::rank(&corpus, "telemetry", 10);
+    let cited = results
+        .iter()
+        .find(|r| r.id == "question-active-surfacing")
+        .expect("proximity should surface the citing node");
+    assert_eq!(cited.via.as_deref(), Some("question-read-telemetry"));
+}


### PR DESCRIPTION
This is the query verb the read path has been missing: `kos ask <question>` gives agents and humans ranked, scoped retrieval mid-session, so Query stops being Gap 0 and becomes a working verb of the operating loop. Additive only; no existing verb changes.

What it does:
- Ranks the nearest graph plus findings by lexical score (id/title/body weighted, stopwords dropped), then a graph-proximity boost that surfaces a node because it cites or is cited by a strong hit (the lift grep cannot produce), then a tier weighting so bedrock outranks a ruled-out node at equal lexical strength while graveyard and superseded items are still returned and tagged, never hidden.
- Every result carries provenance: id, type, confidence tier, date, score, snippet, and a `via` note when proximity pulled it in. `--json` emits the same fields; `--target` scopes to one graph; `--limit` bounds output.
- Logs its served ids as consultation-class reads through the telemetry slice (kos#95), fail-open like orient, so adoption is measurable against the frontier node's pre-registered criterion.
- No embeddings, vector store, or reranker: the Phase 0 scope guard against becoming flyloft-inside-kos.

Verified against the real 130-item kos graph: `ask "read telemetry"` ranks `question-read-telemetry-decision-value` top at 30.6, and ranks 6 and 7 carry neither query term, surfacing purely through graph proximity (the frontier node's success-signal b, demonstrated live). 40 tests (12 new), clippy -D warnings and fmt clean. `load_all_nodes` made pub(crate) so ask reuses orient's loader rather than reimplementing it.

Refs: aae-orc-jajn3