### PR TITLE
finding(kos): relocate kos-subject records from the orc graph (federation trio, chat-probe gap, read-surface ADR, read-path idea)

### DIFF
--- a/_kos/findings/finding-131-kos-node-ids-collide-across-graphs.md
+++ b/_kos/findings/finding-131-kos-node-ids-collide-across-graphs.md
@@ -1,0 +1,251 @@
+# finding-131: kos node ids collide across graphs, and the readable-slug scheme has no defense against it
+
+**Date:** 2026-08-15
+**Status:** OBSERVED. A specimen surfaced during a placement audit of the
+marvel-related nodes. No change applied to either graph (a marvel session may
+be live); this file records the problem and sets up the study.
+**Scope:** kos-tool id design. The observation is cross-repo (the orc graph
+against the marvel graph), so the finding lives at the composition layer per
+the orc rule for cross-repo findings, but it is a finding **for kos**: kos
+assigns and resolves node ids, and kos is where the fix belongs. When kos next
+takes up id scoping, mirror or reference this from `kos/_kos`.
+
+## What was observed
+
+kos node ids are human-readable slugs (`question-permission-model`,
+`val-uncertainty-first`). A slug is unique **within one graph**. It is not
+unique **across graphs**, and nothing in the scheme or the tooling enforces or
+even detects cross-graph uniqueness.
+
+Three ids exist in both `aae-orc/_kos` and `marvel/_kos` right now, all in the
+frontier tier:
+
+| id | orc title | marvel title |
+|---|---|---|
+| `question-multi-host` | Multi-Host Scheduling | Multi-Host Scheduling via Switchboard |
+| `question-permission-model` | Permission Model: Environment Construction + Internal Capabilities | What is the permission model: environment construction + internal RPC capabilities? |
+| `question-stream-attachment` | Stream Attachment Strategy | Which stream-attachment strategy does each runtime adapter use? |
+
+These are not accidental clashes of unrelated concepts. Each pair is the **same
+question at two altitudes**: the orc holds the composition-layer framing, marvel
+holds the implementation framing. That is the intended summary-and-detail split
+(orc charter scope rule, session-016). The problem is that the split is
+expressed by **reusing one id in two graphs**, and there is no link, edge, or
+marker saying "these are the orc view and the marvel view of one question."
+
+## Why it is a defect, not a curiosity
+
+- **Validation is blind to it.** `kos validate` runs per graph. Running it in
+  the orc validated 100 nodes and never saw marvel; running it in marvel
+  validated 83 and never saw the orc. Neither run can report that two copies of
+  `question-permission-model` exist, or that they have drifted.
+- **Edge references are ambiguous across graphs.** An `edges:` target of
+  `question-permission-model` resolves to a **different node** depending on
+  which graph the reader is standing in. Cross-graph edges (which the platform
+  will want as knowledge federates) have no unambiguous target.
+- **Drift is silent and bidirectional.** The two copies can diverge with no
+  signal. The titles above already differ; content divergence would be
+  invisible until a human happened to read both.
+
+## Why this will get worse (the reason to solve it now)
+
+There are 16-plus subrepos, and the direction is for more of them to grow their
+own `_kos` graph (marvel, kos, sidestep, and others already have one). Slugs are
+allocated independently per graph, from the same small vocabulary of obvious
+words (`question-permission-model`, `question-multi-host`, `elem-runtime-*`).
+Independent allocation from a shared vocabulary guarantees collisions, and the
+collision rate rises with the number of graphs. The scheme that reads best at
+one graph fails hardest at many.
+
+## The design tension, and prior art to study
+
+The tension is **readability against collision-resistance**, and other systems
+have already paid for both horns:
+
+- **bd (beads)** solved collision with a project prefix plus a short
+  collision-resistant suffix (`aae-orc-dqhf`, `aae-orc-b56ja`). It buys global
+  uniqueness at the cost of readability: `aae-orc-dqhf` tells a human nothing
+  about what the issue is without a lookup. This is the "difficult for humans to
+  identify references" cost. bd accepts it because its ids are handles, not
+  descriptions. Study: exactly how bd generates the suffix (length, alphabet,
+  collision handling), how the prefix namespaces, and how it stays stable across
+  the Dolt server.
+- **git** solved it with a **two-layer** model: a content-addressed SHA is the
+  canonical, collision-resistant, opaque identifier, and humans work through
+  refs (branch and tag names) that point at SHAs. Readability and uniqueness are
+  separated into two layers rather than traded off in one string. This is the
+  closest match to the combine-hypothesis below. Study: how refs resolve to
+  objects, how ambiguous short SHAs are handled, how tags provide stable human
+  names.
+- **Other projects worth a look:** kubernetes namespaced names
+  (`namespace/name`, uniqueness scoped by namespace, readable and unique
+  together); ULID and UUIDv7 (sortable, unique, opaque); Sqids and nanoid
+  (short, url-safe, tunable collision resistance); Nix store paths
+  (hash-plus-human-name in one path, `hash-name`); DOI and ISBN (registered
+  namespaced identifiers for a federated corpus). Each is a different point on
+  the readable-versus-unique curve.
+
+## Hypothesis to test
+
+Do not replace the slug. **Combine the two layers, the way git does.** Keep the
+human-readable slug as the reading and authoring surface, and issue a
+collision-resistant canonical id alongside it. Candidate shapes to evaluate:
+
+1. **Namespace prefix** (k8s-style): the graph name scopes the slug, so
+   `marvel:question-permission-model` and `aae-orc:question-permission-model`
+   are distinct canonical ids while both keep their readable slug. Cheapest;
+   readable; makes cross-graph edges unambiguous.
+2. **Two-layer with an opaque canonical id** (git-style): a short
+   collision-resistant id (bd-style suffix or a short hash) is the canonical
+   identity; the slug is a human alias that resolves to it. Most robust; adds a
+   resolution step.
+3. **Hybrid** (Nix-style): `slug-<shortid>` in one string, readable and unique
+   at once, at the cost of longer ids.
+
+A related need surfaces from the specimen: the three collisions want an
+**explicit cross-graph relationship** (orc-summary-of / marvel-detail-of), not
+only a unique id. Collision-resistant ids and cross-graph linking are two parts
+of the same federation problem and should be studied together.
+
+## Recommended probe
+
+A study (not yet filed as a work item; proposed for the next step): survey bd,
+git, and the projects above; state where each lands on readability versus
+uniqueness; and recommend one of the three candidate shapes for kos, with a
+migration path that does not break existing slugs or existing edges. Output: a
+kos-side node and a finding. This is a kos-tool change, so it also needs a home
+in `kos/_kos`.
+
+## The immediate specimen (handled separately)
+
+The three colliding ids are a live cleanup question independent of the general
+fix. That decision (which copy is authoritative, whether to namespace them now,
+or whether to express the summary-detail link some other way) is being taken up
+directly rather than waiting on the id-scheme study. This finding records the
+class; the specimen is the immediate work.
+
+## Update 2026-08-15: fleet-wide sweep revises the prevalence and the shape
+
+The placement audit widened from marvel to all 20 graphs. The original three
+collisions were a marvel-only sample. The real map:
+
+**13 exact-id collisions across two axes this finding did not capture.**
+
+Axis 1, orc against a subrepo (8): `question-multi-host`, `question-permission-model`,
+`question-stream-attachment` (the original three, orc/marvel), plus
+`question-marvel-service-provider-shape` (orc/marvel, created this session),
+`question-kos-bridge` (orc/spectacle), `question-pack-format` (orc/spectacle),
+`question-session-bootstrap` (orc/forestage), and `grv-kos-as-task-tracker`
+(orc/kos).
+
+Axis 2, subrepo against subrepo (5), a class this finding never named:
+`question-marvel-integration` (curtain/switchboard), and a four-id cluster
+`elem-vendored-spec`, `grv-raw-http-escape`, `question-audit-mining`,
+`question-distribution` (bloomctl/sidestep).
+
+**Two sub-classes inside axis 2.** The curtain/switchboard case is one concept
+("how do I integrate with marvel") independently and correctly instantiated in
+two graphs. The bloomctl/sidestep cluster is the sharper case:
+**sibling-replication**, where projects built from a shared design template (the
+sidestep pattern) independently coin identical ids for the same recurring
+concept. Neither is a within-graph defect. The candidate fix differs from the
+orc/marvel summary-detail split: an orc-level shared-parent node ("the sidestep
+pattern"), genuinely cross-cutting, that each sibling `instantiates`, rather
+than namespacing.
+
+**The larger finding: exact-id collision is the detectable minority.** The
+sweep detects collisions by filename. That undercounts, because the same concept
+frequently lives under DIFFERENT ids in two graphs, invisible to any id scan.
+Measured examples: orc `question-runtime-adapter` vs marvel
+`elem-runtime-adapter-framework`; orc `question-agent-protocol` vs marvel
+`question-agent-communication-broker`; orc `question-gateway-type` vs marvel
+`question-gateway-external-api`; sidestep `elem-primitives-over-composites` vs
+bloomctl `elem-primitive-layer`. Exact-id collision is the visible tip; concept
+duplication under divergent ids is the mass under the water. Any prevalence tool
+(finding-133) must compare subject and content, not ids alone.
+
+**The fleet already runs the unmanaged fixes.** Two of this finding's candidate
+shapes are already in use, without tooling: subrepo graphs carry `aae-orc::`
+namespaced cross-graph edge targets (marvel, forestage, curtain, switchboard),
+which `kos validate` tolerates as warnings (finding-133); and the sibling
+projects cross-reference each other in prose ("Same ruling as sidestep G1",
+"Threshold prior from sidestep"). Hypothesis 1 (namespace prefix) is not
+hypothetical; it is deployed and unmanaged. The design job is to ratify and tool
+what the graphs already do, not to invent it.
+
+The immediate specimens are being handled via `_kos/relocations.md` (the
+interim forwarding index) and per-node `RELOCATION-PENDING` markers, pending the
+id scheme and the move primitive (finding-132).
+
+## Update 2026-08-16: the collision class is intra-graph too (finding numbers)
+
+The orc graph itself produced two specimens of the same allocation
+failure on its own FINDING numbers, a surface the original write-up
+never named:
+
+- finding-123 is a standing pair:
+  `finding-123-harness-invocation-agent-identity-survey` and
+  `finding-123-org-owned-fork-silently-disables-maintainer-edits`
+  (unresolved at this writing).
+- finding-136 was a pair for three hours:
+  `finding-136-chat-as-probe-surface-harvest-gap` (committed 15:16,
+  PR #225) and `finding-136-channel-selection-is-launcher-side`
+  (committed 15:19, PR #226), two concurrent sessions three minutes
+  apart. Resolved same day by PR #227: first-committed keeps the
+  number; the later file renumbered to finding-137, whose renumbering
+  note records the event from its side.
+
+The mechanism and its fix were ALREADY ON THE BOARD before this
+collision happened: `aae-orc-ul2h` (finding-number allocation:
+prevent parallel-session collisions) and `aae-orc-vxaa` (allocate
+the number at merge, not at authoring) are open bd tasks that name
+the read-time-allocation race and the reservation-at-commit fix
+outright. It is the read-max-plus-one race of finding-105 (session
+numbers, Race A in session-close-mutex.md) expressed on a second
+counter, and the tickets to close it predate the specimen.
+
+The process observation this update exists to record: three
+concurrent sessions handled the 136 collision (detected it,
+diagnosed allocation-at-read, converged on first-committed-wins,
+executed the renumber) and NONE of them consulted bd first, so all
+three re-derived what ul2h and vxaa already said. Every prop existed;
+no session ran one search. That is an F19/F25 instance
+(active-surfacing gap; props without a backdrop) on the exact subject
+matter of this finding, and it is stronger evidence for those
+frontier questions than the collision itself.
+
+What the specimens add to the record proper: the original write-up
+treated collision as a CROSS-graph property of readable slugs; the
+intra-graph pairs show the class is allocation discipline, indifferent
+to whether the id is a semantic slug or a sequential integer. The
+id-scheme study (aae-orc-hf58k) should take allocation discipline as
+an axis beside readability and uniqueness, and the fix design belongs
+to ul2h/vxaa, not to this addendum.
+
+Resolution practice demonstrated by the 136 pair (recorded as
+practice, not ratified): first-committed keeps the number; the later
+entry renumbers itself with a note; history is never rewritten.
+
+Addendum cross-references: aae-orc-ul2h, aae-orc-vxaa (the
+pre-existing fix tickets), aae-orc-hf58k (id-scheme study),
+finding-105 and `.claude/rules/session-close-mutex.md` (Race A),
+`question-kos-multi-writer-concurrency` (multi-writer story),
+`finding-137-channel-selection-is-launcher-side` (renumbering note),
+`finding-136-chat-as-probe-surface-harvest-gap` (the number-keeper).
+
+## Cross-references
+
+- Placement audit that surfaced the specimen: this session (marvel-service-
+  provider design, 2026-08-14/15).
+- Frontier node that spans the same graphs: `question-marvel-service-provider-shape`.
+- Related kos-tool concerns: `question-kos-multi-writer-concurrency`,
+  `question-cross-repo-knowledge` (F10, the composition-layer knowledge
+  problem this is one mechanism of).
+- kos schema: `kos/schema/node.schema.yaml` (ids are described as "stable,
+  unique, never reused" but uniqueness is scoped to one graph by implication,
+  never stated as cross-graph).
+
+## bd tracking
+
+- aae-orc-hf58k (kos: node ids collide across graphs; id scheme study). bd
+  work-queue anchor; this finding is the authoritative record.

--- a/_kos/findings/finding-132-kos-has-no-move-or-rename-with-forwarding.md
+++ b/_kos/findings/finding-132-kos-has-no-move-or-rename-with-forwarding.md
@@ -1,0 +1,123 @@
+# finding-132: kos has no way to move, rename, or rescope a node without orphaning its references
+
+**Date:** 2026-08-15
+**Status:** OBSERVED (anticipatory). No relocation was performed; this records a
+capability gap that the marvel-node placement audit made concrete. A finding
+**for kos**: relocation is a kos-tool concern.
+**Scope:** kos-tool id and reference integrity. Sibling of finding-131 (id
+collision) and finding-133 (cross-graph awareness); the three are facets of one
+federation problem.
+
+## The gap
+
+Nodes get misfiled, rescoped, redefined, and moved. It is not a hypothetical:
+the placement audit this session found nodes whose home is arguable and will
+likely change, and the whole point of the audit was that some belong elsewhere.
+Relocation **will** happen, repeatedly, as the graph grows and as scope
+understanding sharpens. kos has no primitive for it that preserves reference
+integrity.
+
+What kos supports today:
+
+- **Moving a node between confidence tiers** (bedrock / frontier / graveyard) is
+  a `git mv` within one graph. The id stays the same, so edges still resolve.
+  This case is handled.
+
+What kos does not support:
+
+- **Renaming a node** (changing its id). Every `edges:` target, every charter
+  reference, and every doc mention pointing at the old id becomes a dangling
+  reference. Nothing updates them and nothing leaves a trail from the old id to
+  the new one.
+- **Moving a node to another graph** (orc to a subrepo, subrepo to orc, subrepo
+  to subrepo). The node leaves its graph entirely; every in-graph reference to
+  it is orphaned, and the destination graph has no record of where it came from.
+  This is the case the placement audit will trigger.
+- **Rescoping or redefining a node in place.** The id and location stay, but the
+  meaning changes. References that were correct now point at something that
+  means something different, with no signal that the target shifted under them.
+
+## Why it matters
+
+Every relocation without forwarding is silent reference rot. The reader who
+follows an old edge, charter line, or doc link lands on nothing, or worse, lands
+on a node that has quietly come to mean something else. At current scale this is
+occasional. As graphs multiply and scope is refined, relocation becomes routine,
+and routine silent rot is how a knowledge graph stops being trustworthy.
+
+## What is needed (shape open, for study)
+
+A relocation primitive that does one of two things, and probably both depending
+on the case:
+
+1. **Update references atomically.** On rename or move, find and rewrite every
+   reference (edges, and ideally charter and doc mentions) to the new id or
+   location. Requires kos to know its full reference set, which today it computes
+   only within a graph.
+2. **Leave a forwarding path.** A tombstone or redirect at the old id that points
+   to the new location, so an old reference resolves through one hop instead of
+   dangling. Followable, and (per finding-133) tolerantly resolvable when the
+   destination is in an unreachable graph.
+
+The primitive must distinguish **moved** (same concept, new home or new id, a
+redirect is correct) from **redefined or superseded** (the concept changed, a
+`supersedes` edge with an `error` or `evolution` signal is correct). kos has
+`supersedes` today; it has no **moved-to** or **relocated** relationship, and the
+two must not be conflated: a redirect says "the same thing lives here now," a
+supersession says "this was replaced by a different thing."
+
+## Prior art to study
+
+- **HTTP 301 / 308** permanent redirect: the canonical "moved, follow this"
+  pattern, and the model for a tombstone that forwards.
+- **DOI and other persistent identifiers**: the identifier survives relocation of
+  the resource; resolution is indirected through a registry. The strongest model
+  for "the id never dies even when the thing moves."
+- **git**: `mv` with rename detection, and refs as movable human names over
+  stable objects.
+- **filesystem symlinks** and **URL permalinks**: the cheap redirect.
+- **Datomic** (kos's stated long-term substrate): entities keep a stable id while
+  attributes and values change over time; history is the record. Relocation as an
+  append, not a destructive move.
+
+## Update 2026-08-15: a third shape, split-on-move
+
+The fleet placement audit surfaced a case the two-way move/rename framing above
+does not cover: a single node whose content serves TWO subjects.
+`question-session-bootstrap` (orc) bundles forestage's own launch layering
+(retired) with how marvel bootstraps an autonomous agent (live). Its correct
+resolution is not a move but a **split**: divide the node, relocate the live
+subject (to marvel), drop or graveyard the dead one (forestage, retired). kos
+has no split primitive, so today this is a manual rewrite that loses the
+original's identity and edges. The relocation primitive study should treat
+split-on-move as a first-class shape beside rename and cross-graph move: one
+source node becomes two (or more) target nodes, with forwarding from the old id
+to the primary successor and a recorded derivation to the others.
+
+The same audit also surfaced the reverse-reference need (an orc node that three
+subrepo graphs must be able to point AT); that is a resolution concern and is
+recorded in finding-133, not here.
+
+## Recommended probe
+
+Fold into the finding-131 id-scheme study, or run beside it: design the
+relocation primitive (rename, cross-graph move, rescope) with a forwarding
+record and a reference-update pass, and a clear split between moved and
+superseded. Output a kos-side node and a finding.
+
+## Cross-references
+
+- finding-131 (id collision across graphs): a stable, collision-resistant id
+  makes forwarding tractable; the two studies are joined.
+- finding-133 (cross-graph awareness): cross-graph moves need tolerant
+  resolution of the forwarding target.
+- `question-cross-repo-knowledge` (F10), `question-charter-management` (charter
+  references are one of the reference sets that rot on rename).
+- kos schema: `kos/schema/node.schema.yaml` ("never reused" ids and the
+  `supersedes` edge are the nearest existing pieces; neither covers move).
+
+## bd tracking
+
+- aae-orc-0ges9 (kos: no move/rename/split with forwarding; relocation
+  primitive study). bd work-queue anchor; this finding is the authoritative
+  record.

--- a/_kos/findings/finding-133-cross-cutting-knowledge-invisible-from-within-a-project-graph.md
+++ b/_kos/findings/finding-133-cross-cutting-knowledge-invisible-from-within-a-project-graph.md
@@ -1,0 +1,133 @@
+# finding-133: cross-cutting knowledge is invisible from within a project's graph, and kos has no tolerant cross-graph reference
+
+**Date:** 2026-08-15
+**Status:** OBSERVED. The more serious of the federation findings. A finding
+**for kos**, and the graph-level form of F10 (cross-repo knowledge continuity).
+**Scope:** kos-tool federation. Sibling of finding-131 (id collision) and
+finding-132 (move with forwarding); together they are the federation problem.
+
+## The problem
+
+A person or agent working inside marvel, using kos, sees marvel's graph and only
+marvel's graph. The cross-project learnings, tests, probes, questions, and ideas
+that are not fully scoped within marvel are invisible from there. The most
+valuable knowledge, the composition-layer knowledge, is exactly the knowledge a
+single project's graph cannot show, because by definition it does not live in
+that project.
+
+The failure is not only that you cannot read it. It is that **you do not know it
+exists.** A marvel session has no signal that there is a cross-project finding, a
+platform-wide test, or an orc-level question bearing directly on what it is doing.
+This is F10 stated at the graph level, and it is the same read-path hole that
+F19 (active surfacing) and F25 (backdrops) keep circling.
+
+## Requirements (the shape is open; this sets up the study)
+
+1. **A cross-graph reference.** A marker inside marvel's graph that says "there
+   is more about this topic in another graph." The shape is undecided: a
+   reference node, an edge with a cross-graph target, or a lightweight stub.
+   Deciding it is part of the study, and it is entangled with the id scheme
+   (finding-131): a cross-graph reference needs a target id that is unambiguous
+   across graphs.
+
+2. **Unreachable-reference tolerance (hard requirement).** kos must not hang,
+   freeze, error out, or conclude "bad reference" when the referenced graph is
+   not reachable. Reachability is a real boundary, not an error: a user may have
+   access to marvel's graph and no access to aae-orc at all. The correct behavior
+   is informational degradation: "there is a reference here to node X in aae-orc,
+   which cannot currently be reached," surfaced as a fact, never as a validation
+   failure or a hang. Today kos treats an unresolved edge target as a warning
+   within one graph; a cross-graph target that is simply out of reach is a
+   different case and must be handled as absence-of-access, not
+   absence-of-node.
+
+3. **Level-of-detail projection across graphs.** A summary, lower-detail node MAY
+   live in marvel: the marvel-relevant slice of a cross-cutting topic, explicitly
+   marked as **not the authority**, pointing to the authoritative detailed node
+   in aae-orc. This is the F25 stage-rig distinction across a graph boundary: the
+   local summary is a backdrop (authored, shape-preserving, not the record); the
+   remote authoritative node is the prop (verbatim, full fidelity). The local
+   reader gets oriented; the record stays single and authoritative.
+
+4. **Backref-aware revision.** The authoritative detailed node needs to know its
+   backref links, where its summaries live across graphs, so that when it is
+   updated it can flag or revise the projections that depend on it. Bidirectional
+   awareness: the authority knows its projections; each projection knows its
+   authority and is marked non-authoritative. Without this, LoD projections
+   silently drift from the record, which is the finding-131 divergence hazard in
+   a new place.
+
+## This needs a prevalence analysis, not only a design
+
+Before designing the mechanism, measure how common the problem already is.
+finding-131 found three cross-graph id collisions, each a same-topic pair. Those
+are the visible tip: any node whose knowledge is cross-cutting but which lives in
+only one graph is a silent instance, and there is no current way to count them.
+The study needs tooling that scans the graphs and estimates how much
+cross-cutting knowledge is currently siloed, so the fix is sized against real
+prevalence rather than a guess.
+
+## Update 2026-08-15: fleet audit sharpens three of the requirements
+
+The placement audit over all 20 graphs produced concrete evidence for this
+finding.
+
+**The reference direction runs both ways.** The requirements above assume a
+subrepo needs to see cross-cutting knowledge held elsewhere. The audit found the
+reverse too: `question-persona-model` is correctly held at orc (its subject is
+the B14 taxonomy, a composition primitive), and marvel, sideshow, and forestage
+each need a reference TO it. So the cross-graph reference is not only
+subrepo-reaching-up; it is also orc-reaching-down to several subrepos at once.
+The mechanism must be symmetric.
+
+**Unreachable-tolerance is already deployed, unmanaged.** Requirement 2 is not
+speculative. Subrepo graphs already carry `aae-orc::`-prefixed edge targets
+(marvel, forestage, curtain, switchboard), and `kos validate` already degrades
+them to warnings ("edge target 'aae-orc::...' not found in nodes/") rather than
+failing. The tolerant behavior this finding asks for exists by accident. The job
+is to make it intentional: distinguish out-of-reach (absence of access) from
+not-found (absence of node), which the current warning does not.
+
+**The prevalence pass must compare subjects, not ids.** finding-131's fleet
+sweep (updated 2026-08-15) shows exact-id collision is the detectable minority;
+the larger mass is the same concept living under DIFFERENT ids in two graphs
+(orc `question-runtime-adapter` vs marvel `elem-runtime-adapter-framework`, and
+others). A prevalence tool that counts id collisions will therefore report a
+small number and miss most of the siloed cross-cutting knowledge. The pass this
+finding calls for has to cluster by subject and content similarity, not by id,
+or it measures the wrong thing.
+
+## Prior art to study
+
+- **DNS** delegation and referrals: authoritative-elsewhere with a followable
+  pointer, and graceful behavior when a zone is unreachable.
+- **Federated and distributed systems** with partition tolerance: a reference to
+  an unreachable partition is a known state, not a crash. (CAP framing: choose
+  availability of the local read over consistency with the unreachable graph.)
+- **Wikipedia interwiki links and hatnotes** ("see also, on another wiki"): the
+  human pattern for "more exists elsewhere," including how it degrades when the
+  target is missing.
+- **Symlinks and DOIs again** (shared with finding-132): the followable pointer
+  whose target may be absent.
+- **HippoRAG / graph-retrieval work** and the F25 stage-rig literature: LoD
+  projection with a preserved authoritative source.
+
+## Recommended probe
+
+A study, with two outputs: (1) the cross-graph reference shape (ref node vs edge
+vs stub), the tolerance contract for unreachable targets, and the LoD
+projection-plus-backref model; and (2) a prevalence pass over the existing
+graphs. Joined with finding-131 (ids) and finding-132 (movement) as the
+federation study. Output: kos-side nodes and a finding, plus a prevalence number.
+
+## Cross-references
+
+- F10 (`question-cross-repo-knowledge`): this is F10 at the graph level.
+- F19 (active knowledge surfacing) and F25 (`question-stage-rig-information-
+  architecture`): the LoD-projection requirement is the stage rig across a graph
+  boundary; the "you do not know it exists" failure is the F19 hole.
+- finding-131 (id collision) and finding-132 (move with forwarding): the same
+  federation problem; a cross-graph reference needs a cross-graph-unique id and a
+  tolerant resolver.
+- `question-marvel-service-provider-shape`: a live example of a cross-cutting
+  node whose knowledge a marvel-only reader cannot currently see.

--- a/_kos/findings/finding-136-chat-as-probe-surface-harvest-gap.md
+++ b/_kos/findings/finding-136-chat-as-probe-surface-harvest-gap.md
@@ -1,0 +1,69 @@
+# finding-136: operator chat is a probe surface with no harvest step, and repo sessions have started citing its ghosts
+
+**Date:** 2026-08-16
+**Status:** OBSERVED. Small finding; no new rule this wave.
+**Scope:** orc-level, the collaboration process itself (not any one component).
+**Trigger:** reconciling the read-path record surfaced two references to a
+"substrate report" that no repo session could open.
+
+## The finding
+
+Planning conversations in the operator chat are a probe surface. They produce
+the same class of output the kos cycle expects from a probe (a report, a
+verdict, a design with pre-registered confidences), but they carry no harvest
+obligation, so the output exists in the operator's context and in whatever
+ticket text quotes it, and nowhere on disk. For a repo session, an
+uncommitted chat artifact does not exist. The gap is structural, not
+incidental: nothing in the cycle notices that a probe happened somewhere a
+`_kos/` directory could not see.
+
+## Evidence
+
+Two references in the current record pointed at the same missing document.
+
+1. **bd `aae-orc-1od3`** ("substrate report not in graph") records design-field
+   claims inherited from ticket `isie`'s lineage. The claims read as settled
+   findings; their source was a chat-produced report with no committed prop
+   behind it.
+2. **The initial-analysis section 2** cited the same substrate report as if it
+   were a graph artifact.
+
+The report was real. It was produced in conversation, and it was committed on
+2026-08-16 as `docs/kos-substrate-alternatives.md`. Until that commit,
+both citations were pointing at a ghost, and neither citation looked like a
+gap from inside a repo session; each looked like a normal reference to prior
+work.
+
+## Why it recurs
+
+Every session where substantive work happens in chat reproduces the
+conditions. The cost is asymmetric in the way that makes a failure durable:
+the chat participant pays nothing to leave the artifact uncommitted, and the
+next repo session pays the whole cost of discovering that a cited document is
+not there. Downstream, an uncommitted artifact can be cited confidently
+enough that its absence is read as a filing error rather than a missing
+source.
+
+## Disposition
+
+Recorded, no rule this wave. Two things would raise it:
+
+- A third instance of a repo session citing an uncommitted chat artifact.
+- Any case where the uncommitted artifact's absence changed a decision rather
+  than merely delaying one.
+
+The adjacent rule family is `.claude/rules/tooling-friction.md` (capture
+before workaround); this failure has the same shape, with the capture point
+moved from "before applying a workaround" to "before the chat that produced
+the artifact ends." If it recurs, it graduates to a frontier question node in
+the orc graph and, if the shape holds, a behavior-trigger rule matching the
+existing family.
+
+## Cross-references
+
+- `docs/kos-substrate-alternatives.md` (the artifact, committed 2026-08-16)
+- bd `aae-orc-1od3` (report located; remaining work is naming the two
+  "five properties" lists distinctly and tracing `isie`'s design-field claims
+  to props or tagging them asserted-unverified)
+- `.claude/rules/tooling-friction.md` (adjacent rule family)
+- `docs/proposals/read-path-first-steps.md` (the wave that surfaced this)

--- a/_kos/ideas/kos-read-path-gap.md
+++ b/_kos/ideas/kos-read-path-gap.md
@@ -1,0 +1,117 @@
+# kos-read-path-gap
+
+*Criticism received and accepted: kos seeks to encode knowledge, but
+query/reading is non-existent. Cache writes are expensive — and more
+so if you never read. Captured 2026-07-15; an area Michael was
+encouraged to work on, now grounded by the organizing-inference thesis
+(the library institution: judged by circulation, not acquisition) and
+by two same-day pieces of evidence.*
+
+Captured: 2026-07-15
+Source: external criticism relayed by Michael + session evidence.
+Tags: [atelier]
+Related: F19 (active surfacing — the PUSH half; this is the PULL
+half), F25 (stage rig / backdrops), F10 (cross-repo continuity),
+flyloft charter F2 (the designed retrieval substrate),
+finding-044 + `bd-orient-backdrop-missing.md` (s045 — the empirical
+failure), `organizing-inference-at-scale.md` (the crosswalk method
+needs this to run against our own record), `.claude/rules/agent-tools.md`
+(aq — the embryonic read path, see direction 2).
+
+## The criticism, precisely
+
+kos's verb set is almost entirely producer-side: `idea`, `question`,
+`probe`, `finding` (scaffolds), `harvest`/`promote` (conventions),
+`validate`, `drift`, `reflect`, `compact`, `charter render` — all
+write-path or write-hygiene. The read path is `kos orient` (bulk
+per-cwd dump at session start) and nothing else. There is:
+
+- no query verb ("what do we know / what did we decide / what did we
+  rule out about X?")
+- no ranked or scoped retrieval into a working context mid-session
+- no read telemetry — nothing records whether a node has EVER been
+  consulted
+
+A knowledge system with writes and no reads is a warehouse, not a
+library. Worse than zero ROI: unread knowledge still bills —
+maintenance, drift management, schema migrations, and orient-dump
+context tokens are all paid on the write side regardless of whether
+any read ever occurs.
+
+## Evidence (all local, two from today)
+
+1. **s045 (finding-044):** four architectural pivots in one session;
+   every prop needed existed in the graph; nothing surfaced them. F25
+   filed it as "backdrops missing." This file names the complementary
+   read: even with backdrops, there was no verb the agent could have
+   used to ASK.
+2. **Today, the orient bug nobody noticed:** `kos orient` in marvel
+   has been silently skipping 14 of its node files on schema drift
+   (unknown edge types). Nobody noticed the reads were broken — the
+   defining tell of a write-only system. (Broken reads on a read-heavy
+   system page someone in minutes.)
+3. **Today, the synthesis path:** the vsdd→marvel→thesis arc worked
+   because a human curated the reading list (issues, review corpus,
+   code). "What do we know about marvel's resource model?" was
+   unanswerable by any kos verb, though the answer existed in
+   fragments across five documents.
+
+## The institutional frame
+
+Libraries are judged by circulation. Citation is the academy's read
+telemetry — an artifact's authority is a count of *reads that
+mattered*. A records office that only files is dead weight; the
+circulation desk is what makes the archive an asset. (See the library
+row in organizing-inference-at-scale.md's checklist.)
+
+## Candidate directions (pre-hypothesis, cheapest first)
+
+1. **Read telemetry via the existing wrappers.** `aq finding/node/
+   idea/charter` are already the human-and-agent read path — one
+   logline each and the graph gets circulation counts for ~free.
+   Downstream: a "cold nodes" report (never-read bedrock is suspect;
+   a frontier node read 20 times is signaling priority). Reads become
+   evidence in promotion decisions — the missing complement to
+   `reflect`'s harvest-debt (which measures unwritten knowledge but
+   not unread knowledge).
+2. **`kos ask <question>`** — scoped, ranked retrieval over
+   nodes/findings/ideas. Interim implementation can be lexical +
+   graph-proximity (orient's loader already parses everything);
+   flyloft is the designed substrate when it exists. This must NOT
+   grow into flyloft-inside-kos (composition-analysis item 4 warns
+   exactly this) — the verb is the contract; the substrate swaps.
+3. **The crosswalk as query pattern.** The re-discovery preventer:
+   before designing, query the record — ours and civilization's.
+   Making `kos ask` answer "what did we rule out about X and why" is
+   the graveyard finally paying rent.
+4. **Read-side acceptance test for writes.** A finding isn't done
+   until it's *findable*: the harvest checklist gains "would `kos ask`
+   surface this for the question it answers?" — cheap while ask is
+   lexical, honest forever.
+
+## What this is not
+
+Not a replacement for F19's predictor (push) — pull and push are the
+two halves of active knowledge; pull is buildable now with lexical
+tools, push waits on cue semantics. Not flyloft — flyloft is the
+retrieval substrate; this is the missing kos *verb* and the missing
+telemetry that would tell us whether any of it earns its keep.
+
+## Crystallized (2026-08-16)
+
+Directions 1 and 2 have owners now. The idea stays here as the source;
+the testable questions live in kos's own graph, since kos is their
+subject.
+
+- Frontier questions, `kos/_kos/nodes/frontier/`:
+  `question-read-telemetry-decision-value` (does measuring circulation
+  change a later decision, or does the instrument go unread like the
+  graph it measures), `question-kos-ask-retrieval-value` (does the verb
+  beat grep on real session questions, and does it get used), and
+  `question-read-surface-sequencing` (does verb-first-then-MCP hold, or
+  does the benefit only arrive inside the agent task loop). Each carries
+  a success signal and a kill condition.
+- bd: `aae-orc-2qlx0` (read-telemetry collection slice, carrying the
+  pre-registration amendment) and `aae-orc-jajn3` (`kos ask` Phase 0).
+- Proposal: `kos/docs/proposals/read-path-first-steps.md`.
+- ADR-009 records the single-query-engine decision behind direction 2.

--- a/docs/decisions/adr-009-read-surface-single-query-engine.md
+++ b/docs/decisions/adr-009-read-surface-single-query-engine.md
@@ -1,0 +1,98 @@
+# ADR-009: Read Surface as a Single Query Engine With Three Faces
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-16
+
+## Context
+
+kos has a working write path and almost no read path. The adopted vision
+names this Gap 0 and calls Query the weakest verb of the operating loop.
+Two candidate homes for the read surface were live at once: a kos-side
+MCP server, and flyloft as the retrieval substrate fronting kos. bd
+`aae-orc-di23` asked which one to build, with the criterion "soonest
+surface, federation not foreclosed."
+
+Two constraints bound the answer.
+
+First, flyloft is a skeleton: types only, every verb `todo!()`. Waiting
+for it means shipping no read surface at all.
+
+Second, the Track B sequencing in bd `aae-orc-b0kp` (round 3, item 2)
+puts the M0 schema repair before any MCP surface. The argument is that a
+server over a corrupted graph "serves lies with a nice API"; finding-060
+measured roughly 24 percent undeclared-type edges while validation was
+green, so the corruption is real and invisible to the current checks.
+
+## Considered Options
+
+1. One query engine, exposed through successive faces (chosen).
+2. Two permanent parallel servers: a kos MCP and a flyloft MCP as
+   co-equal read surfaces.
+3. MCP first, before any CLI verb.
+
+## Decision Outcome
+
+**One query engine, three faces over time.**
+
+- **Now:** the `kos ask` CLI verb (bd `aae-orc-jajn3`), lexical plus
+  graph-proximity as the interim ranking. The verb is the contract.
+- **Next:** a kos-side read-only MCP Phase 0 wrapping the same engine,
+  after the M0 schema repair, per `aae-orc-b0kp` round 3 item 2.
+- **Later:** flyloft-mcp federation when flyloft is real, fronting the
+  same engine rather than replacing it.
+
+This satisfies di23's criterion directly: the CLI verb is the soonest
+surface available, and nothing in it forecloses federation, because the
+engine is the asset and the faces are thin.
+
+### Why option 2 was rejected
+
+Two permanent co-equal servers means two ranking implementations and two
+provenance stories over the same graph. When the same question returns
+different answers with different confidence framing depending on which
+server was asked, neither answer can be trusted, and the failure is
+quiet. Maintenance doubles for a benefit that federation over one engine
+already provides.
+
+### Why option 3 was rejected
+
+Per `aae-orc-b0kp`: M0 before MCP. An MCP surface is the point where the
+graph stops being read by people who can notice it is wrong and starts
+being consumed by agents that cannot. Shipping the server first inverts
+the order in which the corruption would surface.
+
+### Positive Consequences
+
+- A usable read surface lands without waiting on flyloft or on M0.
+- One ranking and provenance implementation to test, measure, and
+  correct.
+- Federation stays open; flyloft inherits an engine with measured
+  behavior instead of a specification.
+- Read telemetry (bd `aae-orc-2qlx0`) measures one engine's circulation,
+  so the numbers stay comparable across faces.
+
+### Negative Consequences
+
+- The CLI verb sits outside the agent task loop, so early usage
+  measurement under-counts in-task retrieval. This is held open, not
+  waved away, as `question-read-surface-sequencing`.
+- kos carries a query engine it may eventually hand to flyloft. The
+  standing guard from the read-path idea applies: the verb must not grow
+  into flyloft-inside-kos.
+
+## Links
+
+- `kos/docs/proposals/read-path-first-steps.md` (the plan this decision
+  serves)
+- bd `aae-orc-di23` (the question), `aae-orc-b0kp` (Track B sequencing),
+  `aae-orc-jajn3` (`kos ask` Phase 0), `aae-orc-2qlx0` (read telemetry)
+- `_kos/ideas/kos-read-path-gap.md` (direction 2: the verb is the
+  contract, the substrate swaps)
+- `kos/_kos/nodes/frontier/question-read-surface-sequencing.yaml`
+- vision.md, Gap 0 and the operating loop
+- finding-060 (undeclared-type edges under green validation)


### PR DESCRIPTION
Six records were filed into `aae-orc/_kos` by the mention test. Each subject is kos, so they belong in the kos graph.

## What moved
- **finding-131 / 132 / 133 — the federation trio.** Each declares itself a facet of one problem (*"the three are facets of one federation problem"*); their scope lines are kos-tool id design, reference integrity, and federation. They move as the unit they declare themselves to be. Trio-internal references are bare same-graph ids now; the `aae-orc::` strings in the bodies are descriptive prose about the fleet namespacing convention and stand.
- **finding-136 — chat-as-probe-surface harvest gap.** A gap in the kos probe→harvest cycle: operator chat produces probe-class output the cycle cannot see. Doc paths corrected from `kos/docs/…` to `docs/…` now that it lives in the kos graph.
- **adr-009 — read surface as a single query engine.** The kos read-surface decision, placed **verbatim** in `docs/decisions/`.
- **kos-read-path-gap — the idea** (circulation-desk framing).

## Notes
- `adr-009`: kos records decisions as graph **nodes**, so the native form is a bedrock node. This PR does the least-transformative faithful move (verbatim file) and defers node-conversion to an explicit decision — say the word and I convert it.
- The ~45 orc prose citations of finding-131 (all `class: finding-131.`, **zero edges**) become cross-graph prose references. Non-breaking: `kos validate` checks edge targets, not prose.
- The orc cleanup PR removes these from `aae-orc/_kos` and updates `decisions/index.md`, `relocations.md`, and the roadmap K7 pointer.